### PR TITLE
MAJ documents juridiques

### DIFF
--- a/cypress/e2e/test-completion/url-redirection.cy.js
+++ b/cypress/e2e/test-completion/url-redirection.cy.js
@@ -24,6 +24,8 @@ function goToQuestionAndGet(
 ) {
 	cy.visit(`/simulateur/${rootSimulatorURL}?question=${question}`)
 	clickUnderstoodButton()
+
+	waitWhileLoading()
 	clickCategoryStartButton()
 	cy.get(`[id="id-question-${question}${mosaicFirstQuestion}"]`)
 }

--- a/source/locales/pages/fr/CGU.md
+++ b/source/locales/pages/fr/CGU.md
@@ -10,20 +10,20 @@ L'utilisation de la plateforme est gratuite et ouverte à tous.
 
 ## Article 2 -- Objet
 
-La plateforme Nos Gestes Climat a pour objectif d'évaluer l'empreinte
-carbone individuelle annuelle de consommation, total et par grandes catégories
-(alimentation, transport, logement, divers, services socétaux), de la situer par rapport aux objectifs climatiques. En
-fonction des réponses et du résultat, des gestes personnalisés sont
+La Plateforme Nos Gestes Climat a pour objectif d'évaluer l'empreinte
+carbone individuelle annuelle de consommation, totale et par grandes catégories
+(alimentation, transport, logement, divers, services socétaux), et de la situer par rapport aux objectifs climatiques. En
+fonction des réponses et du résultat, des actions personnalisées sont
 proposés.
 
 Voir [la page à-propos](/à-propos) pour plus de détails.
 
 ## Article 3 -- Définitions
 
-« L'Utilisateur » est toute personne utilisant la plateforme Nos Gestes
+« L'Utilisateur » est toute personne utilisant la Plateforme Nos Gestes
 Climat.
 
-Les « Services » sont les fonctionnalités offertes par la plateforme
+Les « Services » sont les fonctionnalités offertes par la Plateforme
 pour répondre à ses finalités.
 
 « Le responsable de traitement » est la personne qui, au sens de
@@ -37,20 +37,20 @@ traitements de données à caractère personnel.
 
 ### 4.1 Simulation individuelle
 
-L'utilisateur accède au simulateur au travers du bouton « faire le
+L'Utilisateur accède au simulateur au travers du bouton « faire le
 test », qui enclenche un questionnaire afin de déterminer l'empreinte
 carbone. Les thèmes abordés sont notamment, l'alimentation, le
 transport, le logement, les services sociétaux, ...
 
-Il peut à tout moment cliquer sur le bouton « comprendre le calcul »
+L'Utilisateur peut à tout moment cliquer sur le bouton « comprendre le calcul »
 afin d'en apprendre plus sur le simulateur.
 
 ### 4.2 Simulation sous le monde groupe : conférence et sondage
 
-Grâce à la fonctionnalité conférences, il est possible d'effectuer la
+L'Utilisateur peut, grâce à la fonctionnalité conférences, effectuer la
 simulation à plusieurs en cliquant sur le bouton « faire le test à
-plusieurs ». Un lien aléatoire est généré pour accéder à la conférence,
-et des noms aléatoires, et anonymes, sont attribués aux participants.
+plusieurs ». Un lien aléatoire est généré pour accéder à la conférence
+et des noms aléatoires et anonymes sont attribués aux participants.
 
 Dans ce cas, les résultats sont agrégés en pair-à-pair avec les autres participants de
 la conférence. Une moyenne du groupe est transmise, et comparée à la
@@ -86,11 +86,17 @@ réserve la liberté de faire évoluer, de modifier ou de suspendre, sans
 préavis, la plateforme pour des raisons de maintenance ou pour tout
 autre motif jugé nécessaire.
 
+### L'Utilisateur
+
+L’Utilisateur s’engage à ne pas mettre en ligne des contenus ou informations contraires aux
+dispositions légales et réglementaires en vigueur.
+
 ## Article 6 - Mise à jour des conditions d'utilisation
 
 Les termes des présentes conditions d'utilisation peuvent être amendés à
 tout moment, sans préavis, en fonction des modifications apportées à la
 plateforme, de l'évolution de la législation ou pour tout autre motif
-jugé nécessaire.
+jugé nécessaire. Chaque modification donne lieu à une
+nouvelle version qui est acceptée par les parties.
 
 L'historique de ces mises à jour est consultable dans le dépôt de code ouvert https://github.com/datagir/nosgestesclimat-site.

--- a/source/locales/pages/fr/about.md
+++ b/source/locales/pages/fr/about.md
@@ -64,14 +64,22 @@ audit plus rigoureux par Access 42.
 La déclaration d'accessibilité est visible via [la page
 dédiée](/accessibilite).
 
+Pour en savoir plus sur la politique d'accessibilité numérique de l'Etat : http://references.modernisation.gouv.fr/accessibilite-numerique
+
 Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à
-un contenu ou une fonctionnalité du site, merci de nous en faire part
-[en bas de la page FAQ](/contribuer) ou bien via <rgaa@ademe.fr>) afin
-qu'une assistance puisse être apportée (alternative accessible,
-information et contenu donnés sous une autre forme). Si vous n'obtenez
-pas de réponse rapide de notre part, vous êtes en droit de faire
-parvenir vos doléances ou une demande de saisine au [Défenseur des
-droits](https://www.defenseurdesdroits.fr).
+un contenu ou une fonctionnalité du site, merci de nous en faire part : 
+- [en bas de la page FAQ](/contribuer)
+- via <rgaa@ademe.fr>
+- via <contact@nosgestesclimat.fr>
+
+Si vous n’obtenez pas de réponse rapide de notre part, vous êtes en droit de faire parvenir vos
+doléances ou une demande de saisine au Défenseur des droits.
+Pour le joindre, vous pouvez :
+- Utiliser le formulaire de contact en ligne ici :
+https://formulaire.defenseurdesdroits.fr/code/afficher.php?ETAPE=accueil_2016
+- Composer le 09 69 39 00 00 (du lundi au vendredi de 8h à 20h)
+- Envoyer un courrier (sans timbre) à l’adresse suivante : Défenseur des droits, Libre
+réponse 71120, 75342 Paris CEDEX 07.
 
 ## Mentions légales
 

--- a/source/locales/pages/fr/about.md
+++ b/source/locales/pages/fr/about.md
@@ -52,7 +52,43 @@ On vous dit tout sur notre page [diffuser](/diffuser).
 
 contact\@nosgestesclimat.fr
 
-## Accessibilité
+## Budget
+
+Le budget de Datagir, l'organisation qui développe nosgestesclimat.fr
+est disponible sur la [page budget](https://datagir.ademe.fr/budget/).
+
+
+## Mentions légales
+
+### Editeur de la Plateforme : 
+
+La Plateforme « Nos Gestes Climat » est éditée par :
+
+L’Agence de la Transition écologique (ADEME) :
+
+20, avenue du Grésillé
+BP 90406
+49004 Angers Cedex 01
+France
+
+Téléphone : 02 41 20 41 20
+
+### Directeur de publication
+
+Le directeur de la publication est Monsieur Boris RAVIGNON, Président-directeur général par intérim de l’ADEME.
+
+### Hébergement de la Plateforme
+
+Cette plateforme est hébergée par :
+Netlify
+Inc 2325 3rd Street, Suite 296
+San Francisco, California 94107
+États-Unis
+
+Le site est hébergé sur Netlify. C'est un site statique servi via un CDN : malgré la domiciliation en Californie, le site vous sera servi [depuis
+l'Europe](https://answers.netlify.com/t/is-there-a-list-of-where-netlifys-cdn-pops-are-located/855/2).
+
+### Accessibilité
 
 Le site est partiellement conforme aux normes d'accessibilité numérique.
 
@@ -81,30 +117,13 @@ https://formulaire.defenseurdesdroits.fr/code/afficher.php?ETAPE=accueil_2016
 - Envoyer un courrier (sans timbre) à l’adresse suivante : Défenseur des droits, Libre
 réponse 71120, 75342 Paris CEDEX 07.
 
-## Mentions légales
+### Sécurité
 
-Siège social de l'ADEME :
+Le site est protégé par un certificat électronique, matérialisé pour la grande majorité des
+navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges.
+En aucun cas les services associés à la plateforme ne seront à l’origine d’envoi de courriels
+pour demander la saisie d’informations personnelles.
 
-20, avenue du Grésillé
-
-BP 90406
-
-49004 Angers Cedex 01
-
-Tél. : 02 41 20 41 20
-
-### Directeur de publication
-
-Martin Régner - ADEME
-
-### Prestataire d'hébergement
-
-Netlify, Inc 2325 3rd Street, Suite 296, San Francisco, California 94107
-
-Le site est hébergé sur Netlify. C'est un site statique servi via un CDN
-: malgré la domiciliation en Californie, le site vous sera servi [depuis
-l'Europe](https://answers.netlify.com/t/is-there-a-list-of-where-netlifys-cdn-pops-are-located/855/2).
-
-## Conditions générales d'utilisation
+### Conditions générales d'utilisation
 
 Elles sont disponibles sur [cette page](/cgu).

--- a/source/locales/pages/fr/about.md
+++ b/source/locales/pages/fr/about.md
@@ -16,8 +16,7 @@ Climatique](https://avenirclimatique.org/les-outils/) et
 
 ## Qui le développe ?
 
-Ce calculateur carbone est développé par l'équipe
-Nosgestesclimat de l'[Agence de la transition
+Ce calculateur carbone est développé par l'[Agence de la transition
 écologique](https://www.ademe.fr/) (ADEME) et
 [beta.gouv.fr](https://beta.gouv.fr/), en partenariat avec
 l'[Association Bilan Carbone](https://www.associationbilancarbone.fr/)
@@ -101,4 +100,3 @@ l'Europe](https://answers.netlify.com/t/is-there-a-list-of-where-netlifys-cdn-po
 ## Conditions générales d'utilisation
 
 Elles sont disponibles sur [cette page](/cgu).
-

--- a/source/locales/pages/fr/privacy.md
+++ b/source/locales/pages/fr/privacy.md
@@ -27,6 +27,11 @@ Les modes de simulation en groupe, conférence et sondage, font eux appel à nos
 Nos Gestes Climat est développé au sein de l’Agence de la transition écologique (ADEME). La plateforme numérique Nos Gestes Climat permet grâce à un calculateur d’empreinte carbone personnel de référence d’estimer l’empreinte carbone de consommation des utilisateurs.
 Le responsable de l’utilisation des données est l’Agence de la transition écologique (ADEME) représentée par Monsieur Boris RAVIGNON, Président-directeur général par interim de l’ADEME.
 
+## Qui héberge Nos Gestes Climat ?
+
+L’entreprise Netlify héberge Nos Gestes Climat. Netlify est une entreprise américaine dont le siège social est situé à San Francisco en Californie : https://www.netlify.com/gdpr-ccpa/
+Scalingo héberge les données du sondage : https://scalingo.com/fr/contrat-gestion-traitements-donnees-personnelles
+
 ## Données à caractère personnel traitées
 
 ### a) Données relatives à la simulation
@@ -121,12 +126,6 @@ Le responsable de traitement s’engage à ce que les données soient traitées 
 ### Sous-traitants
 
 Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitement s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
-
-### Hébergement du site Web
-
-Le site Web est hébergé par Netlify, comme indiqué dans les mentions légales sur la page [à propos](/à-propos).
-
-Le serveur de stockage des données du sondage est hébergé par [Scalingo](https://scalingo.com) SAS, 15 avenue du Rhin 67100 Strasbourg France.
 
 ## Cookies
 

--- a/source/locales/pages/fr/privacy.md
+++ b/source/locales/pages/fr/privacy.md
@@ -2,16 +2,12 @@
 
 ## Introduction
 
-La simulation et les calculs se font dans votre navigateur Web, donc les réponses aux
-questions restent chez vous, nous n'en collectons aucune.
+La simulation et les calculs se font dans votre navigateur Web, donc les réponses aux questions restent chez vous, nous n'en collectons aucune.
 
-Cependant, nous suivons quelques informations sur votre utilisation de ce
-simulateur, telles que les pages consultées et le temps passé, dans
+Cependant, nous suivons quelques informations sur votre utilisation de ce simulateur, telles que les pages consultées et le temps passé, dans
 l'unique but de l'améliorer.
 
-En particulier, nous suivons l'adresse de la page de fin de simulation,
-qui contient le total de votre empreinte et sa répartition en grande
-catégories (transport, logement, ...).
+En particulier, nous suivons l'adresse de la page de fin de simulation, qui contient le total de votre empreinte et sa répartition en grande catégories (transport, logement, ...).
 
 Vous pouvez en savoir plus et désactiver ce suivi, qui est fait via une instance étatique du logiciel ouvert Matomo, ci-dessous.
 
@@ -32,7 +28,33 @@ Le responsable de l’utilisation des données est l’Agence de la transition �
 L’entreprise Netlify héberge Nos Gestes Climat. Netlify est une entreprise américaine dont le siège social est situé à San Francisco en Californie : https://www.netlify.com/gdpr-ccpa/
 Scalingo héberge les données du sondage : https://scalingo.com/fr/contrat-gestion-traitements-donnees-personnelles
 
-## Données à caractère personnel traitées
+## Cookies
+
+En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le traitement des données à caractère personnel et la protection de la vie privée dans le secteur des
+communications électroniques, transposée à l’article 82 de la loi n°78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les traceurs ou cookies suivent deux
+régimes distincts.
+Les cookies strictement nécessaires au service ou ayant pour finalité exclusive de faciliter la communication par voie électronique sont dispensés de consentement préalable au titre de
+l’article 82 de la loi n°78-17 du 6 janvier 1978. Les cookies n’étant pas strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la communication par voie électronique doivent être consenti par l’utilisateur.
+Ce consentement de la personne concernée pour une ou plusieurs finalités spécifiques constitue une base légale au sens du RGPD et doit être entendu au sens de l&#39;article 6-a du
+Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l&#39;égard du traitement des données à caractère personnel
+et à la libre circulation de ces données.
+Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des informations relatives à votre navigation et de vous adresser des services adaptés
+à votre terminal (ordinateur, mobile ou tablette).
+
+Nos Gestes Climat utilise Matomo de manière anonymisée et ne nécessite donc pas le consentement conformément aux recommandations de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
+Il convient d’indiquer que :
+
+-   Les données collectées ne sont pas recoupées avec d’autres traitements
+-   Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites
+
+À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment
+sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
+Pour aller plus loin, vous pouvez consulter les ﬁches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
+
+-   [Cookies & traceurs : que dit la loi ?](https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi)
+-   [Cookies : les outils pour les maîtriser](https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser)
+
+## Plus de précisions sur les données traitées
 
 ### a) Données relatives à la simulation
 
@@ -73,8 +95,7 @@ Des cookies sont utilisés afin de suivre l’utilisation du simulateur, telles 
 
 ### e) Questions d'évaluation
 
-Afin de mieux comprendre vos attentes, nous avons ajouter deux questions d'évaluation : à la fin du test, et lors du parcours action.
-Vos résultats aggrégés de simulation sont alors enregistrés au côté de votre évaluation, anonymement, sur un serveur hébergé par l'ADEME via notre prestataire Scalingo, dont le code sera bientôt ouvert [sur github](https://github.com/datagir/nosgestesclimat-server) avec le résultat de la simulation.
+Afin de mieux comprendre vos attentes, nous avons ajouter deux questions d'évaluation : à la fin du test, et lors du parcours action. Vos résultats aggrégés de simulation sont alors enregistrés au côté de votre évaluation, anonymement, sur un serveur hébergé par l'ADEME via notre prestataire Scalingo, dont le code sera bientôt ouvert sur github avec le résultat de la simulation.
 
 ## Bases juridiques des traitements de données
 
@@ -84,22 +105,10 @@ Les données traitées à l’occasion de ces traitements ont plusieurs fondemen
 
 Ces fondements sont précisés ci-dessous :
 
-### a) Données relatives aux résultats de la simulation
+### Données relatives aux résultats de la simulation
 
 Ce traitement est nécessaire à l’exécution d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 Elles permettent de réaliser des statistiques anonymisées sur l’empreinte carbone en France.
-
-### b) Cookies
-
-En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le traitement des données à caractère personnel et la protection de la vie privée dans le secteur des communications électroniques, transposée à l’article 83 de la loi n°78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les traceurs ou cookies suivent deux régimes distincts.
-
-Les cookies strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la communication par voie électronique sont dispensés de consentement préalable au titre de l’article 83 de la loi n°78-17 du 6 janvier 1978.
-
-Les cookies n’étant pas strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la communication par voie électronique doivent être consenti par l’utilisateur.
-
-Ce consentement de la personne concernée pour une ou plusieurs finalités spécifiques constitue une base légale au sens du RGPD et doit être entendu au sens de l'article 6-a du Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l'égard du traitement des données à caractère personnel et à la libre circulation de ces données.
-
-Les cookies de mesure d’audience, lorsque les données sont anonymisées, ne nécessitent pas de consentement. En l’occurrence, la plateforme utilise Matomo dans sa version anonymisée, vous pouvez néanmoins vous opposer au suivi de votre navigation sur ce site web, via l'encart en début de de document.
 
 ## Durée de conservation des données
 
@@ -126,21 +135,3 @@ Le responsable de traitement s’engage à ce que les données soient traitées 
 ### Sous-traitants
 
 Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitement s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
-
-## Cookies
-
-Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des informations relatives à votre navigation.
-
-Le site dépose des cookies de mesure d’audience (notamment nombre de visites, pages consultées), respectant les conditions d’exemption du consentement de l’internaute définies par la recommandation « Cookies » de la Commission nationale informatique et libertés (CNIL). Cela signifie, notamment, que ces cookies ne servent qu’à la production de statistiques anonymes et ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
-
-Nous utilisons pour cela Matomo, un outil de mesure d’audience web libre, paramétré pour être en conformité avec la recommandation « Cookies » de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
-
-Il convient d’indiquer que :
-
--   Les données collectées ne sont pas recoupées avec d’autres traitements
--   Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites
-
-Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
-
--   [Cookies & traceurs : que dit la loi ?](https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi)
--   [Cookies : les outils pour les maîtriser](https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser)

--- a/source/locales/pages/fr/privacy.md
+++ b/source/locales/pages/fr/privacy.md
@@ -95,7 +95,7 @@ Des cookies sont utilisés afin de suivre l’utilisation du simulateur, telles 
 
 ### e) Questions d'évaluation
 
-Afin de mieux comprendre vos attentes, nous avons ajouter deux questions d'évaluation : à la fin du test, et lors du parcours action. Vos résultats aggrégés de simulation sont alors enregistrés au côté de votre évaluation, anonymement, sur un serveur hébergé par l'ADEME via notre prestataire Scalingo, dont le code sera bientôt ouvert sur github avec le résultat de la simulation.
+Afin de mieux comprendre vos attentes, nous avons ajouté deux questions d'évaluation : à la fin du test, et lors du parcours action. Vos résultats aggrégés de simulation (total ainsi que transport, alimentation, logement, divers) sont alors enregistrés au côté de votre évaluation, anonymement, sur un serveur hébergé par l'ADEME via notre prestataire Scalingo, dont le code sera bientôt ouvert sur github.
 
 ## Bases juridiques des traitements de données
 

--- a/source/locales/pages/fr/privacy.md
+++ b/source/locales/pages/fr/privacy.md
@@ -22,9 +22,10 @@ src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&lan
 
 Les modes de simulation en groupe, conférence et sondage, font eux appel à nos serveurs pour aggréger les multiples simulations et les communiquer entre les participants.
 
-## Traitement des données à caractère personnel
+## Qui est responsable de Nos Gestes Climat ?
 
-La présente plateforme Nos Gestes Climat est à l’initiative de l’Agence de la transition écologique, l'ADEME, qui est responsable de traitement des données à caractère personnel collectées par la plateforme.
+Nos Gestes Climat est développé au sein de l’Agence de la transition écologique (ADEME). La plateforme numérique Nos Gestes Climat permet grâce à un calculateur d’empreinte carbone personnel de référence d’estimer l’empreinte carbone de consommation des utilisateurs.
+Le responsable de l’utilisation des données est l’Agence de la transition écologique (ADEME) représentée par Monsieur Boris RAVIGNON, Président-directeur général par interim de l’ADEME.
 
 ## Données à caractère personnel traitées
 

--- a/source/locales/pages/fr/privacy.md
+++ b/source/locales/pages/fr/privacy.md
@@ -20,10 +20,6 @@ css="border: 2px dashed var(--color); max-height: 200px; width: 600px;"
 src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily="
 ></iframe>
 
-> À partir du 18 avril 2023, nous testons un nouvel outil de suivi, lui aussi open source, Plausible, dans l'objectif d'améliorer le service.
-
-> Plausible [est respectueux de votre vie privé](https://plausible.io/data-policy), les informations collectées sont les mêmes qu'à l'heure actuelle et sont totalement anonymes. Vous pouvez refuser ce suivi via [les instructions sur cette page](https://plausible.io/docs/excluding), qui peuvent se résumer à l'[installation du blockeur de publicités uBlock Origin sur le navigateur Firefox](https://addons.mozilla.org/fr/firefox/addon/ublock-origin/).
-
 Les modes de simulation en groupe, conférence et sondage, font eux appel à nos serveurs pour aggréger les multiples simulations et les communiquer entre les participants.
 
 ## Traitement des données à caractère personnel
@@ -56,7 +52,7 @@ Au cours de la simulation en mode conférence, les résultats décrits en introd
 
 #### Mode sondage
 
-Le mode sondage repose sur un serveur hébergé par l'ADEME via notre prestataire Scalingo, dont le code est 
+Le mode sondage repose sur un serveur hébergé par l'ADEME via notre prestataire Scalingo, dont le code est
 et disponible [sur github](https://github.com/datagir/nosgestesclimat-server).
 
 Au préalable de tout partage de données avec notre serveur, l'utilisateur se voit demander s'il veut participer au mode sondage.


### PR DESCRIPTION
Le service juridique a proposé des modifs sur les documents juridiques de NGC : 
- pour les CGU : petites modifs de forme et ajout de quelques phrases de précisions
- pour la politique de confidentialité : mention à Plausible retirée comme on ne va pas l'utiliser ; simplification de la page
- pour les Mentions légales : ajout d'un paragraphe sur la sécurité, réorganisation de la page, petites modifs de formes et quelques phrases de précisions

Commentaire du service juridique sur la politique de confidentialité : "C'est une MAJ. La page actuelle mentionne plein de données qui ne sont pas des données à caractère personnel. J'ai raccourci en précisant juste qui est responsable de NGC, qui héberge NGC (avec les infos sur Netlify, entreprise américaine!) et les infos sur les cookies"

Fixes #956 