### PR TITLE
Corrige le titre de page `undefined` à l'étape Résultats

### DIFF
--- a/source/components/utils/Meta.tsx
+++ b/source/components/utils/Meta.tsx
@@ -19,7 +19,7 @@ export default function Meta({
 	image,
 	url,
 	children,
-}: React.PropsWithChildren | PropType) {
+}: React.PropsWithChildren & PropType) {
 	const { pathname } = useLocation()
 	return (
 		<Helmet>

--- a/source/locales/ui/ui-en-us.yaml
+++ b/source/locales/ui/ui-en-us.yaml
@@ -756,3 +756,5 @@ entries:
   publicodes.planDuSite.stats.lock: Page des Statistiques
   publicodes.planDuSite.sondageDoc: Survey documentation
   publicodes.planDuSite.sondageDoc.lock: Documentation sondage
+  Votre bilan climat personnel - Résultats: Your personal climate report - Results
+  Vous n'avez pas de simulation en cours à sauvegarder.: You have no current simulation to save.

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -571,3 +571,7 @@ entries:
   partages du site: partages du site
   simulations terminées: simulations terminées
   visites sur la page d'accueil: visites sur la page d'accueil
+  '{categoryTitle}': '{categoryTitle}'
+  '{linkKey}': '{linkKey}'
+  Votre bilan climat personnel - Résultats: Votre bilan climat personnel - Résultats
+  Vous n'avez pas de simulation en cours à sauvegarder.: Vous n'avez pas de simulation en cours à sauvegarder.

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -22,7 +22,7 @@ import { AppState } from '@/reducers/rootReducer'
 import { motion } from 'framer-motion'
 import { utils } from 'publicodes'
 import { useEffect } from 'react'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Navigate, useNavigate } from 'react-router'
 import { Link, useParams } from 'react-router-dom'
@@ -48,6 +48,8 @@ const Simulateur = () => {
 	const urlParams = useParams()
 	const searchParams = new URLSearchParams(window.location.search)
 	const simulatorRootNameURL = urlParams['*']
+	const { t } = useTranslation()
+
 	if (!simulatorRootNameURL) {
 		return <Navigate to={`/simulateur/${MODEL_ROOT_RULE_NAME}`} replace />
 	}
@@ -134,7 +136,10 @@ const Simulateur = () => {
 	return (
 		<div>
 			<Meta
-				title={evaluation.rawNode?.title}
+				title={
+					evaluation.rawNode?.title ||
+					t('Votre bilan climat personnel - Résultats')
+				}
 				description={evaluation.rawNode?.description}
 			/>
 			<Title>


### PR DESCRIPTION
Le titre de page était `undefined` à la dernière étape avant d'accéder à ses résultats : 
<img width="940" alt="Capture d’écran 2023-06-22 à 12 37 08" src="https://github.com/incubateur-ademe/nosgestesclimat-site/assets/12382534/91a82bba-5824-4357-b51c-097a64c2861a">
