### PR TITLE
Commente le code empêchant l'affichage multiple du formulaire de newsletter

### DIFF
--- a/source/components/emailing/NewsletterForm.tsx
+++ b/source/components/emailing/NewsletterForm.tsx
@@ -106,9 +106,13 @@ export const NewsletterForm = () => {
 			setIsSending(false)
 		}
 	}
+	/*
+	// Pour permettre à ceux n'ayant pas reçu le premier email d'inscription
+	// je commente ce bloc pour le moment, à décommenter d'ici quelques mois
 
 	if (hasSubscribedToNewsletter && !hasSubscribedToNewsletterRef.current)
 		return null
+	*/
 
 	return (
 		<div


### PR DESCRIPTION
Nous avons besoin de permettre à ceux n'ayant pas reçu leur email d'inscription contenant leurs liens pour retrouver leur simulation et de partage de se réinscrire afin de le recevoir.