### PR TITLE
blog : add illustration and add alt txt

### DIFF
--- a/source/sites/publicodes/pages/Blog.tsx
+++ b/source/sites/publicodes/pages/Blog.tsx
@@ -22,8 +22,18 @@ export default () => {
 				image="https://nosgestesclimat.fr/images/dessin-nosgestesclimat.png"
 			/>
 			<h1 data-cypress-id="blog-title">{title}</h1>
-			<p>{description}</p>
-
+			<div
+				css={`
+					text-align: center;
+				`}
+			>
+				<img
+					alt={description}
+					css="width: 100%; height: 237px; object-fit: cover; object-position: 100% 0px;"
+					src="https://nosgestesclimat.fr/images/dessin-nosgestesclimat.png"
+				/>
+				<p>{description}</p>
+			</div>
 			<ScrollToTop />
 			<ul
 				css={`

--- a/source/sites/publicodes/pages/Blog.tsx
+++ b/source/sites/publicodes/pages/Blog.tsx
@@ -4,21 +4,8 @@ import { Link } from 'react-router-dom'
 
 import { ScrollToTop } from '@/components/utils/Scroll'
 import { getCurrentLangInfos } from '@/locales/translation'
-import React, { Suspense } from 'react'
 import { blogData } from './BlogData'
 import { dateCool, extractImage } from './news/NewsItem'
-const LazyIllustration = React.lazy(
-	() =>
-		import(
-			/* webpackChunkName: 'AnimatedIllustration' */ '@/components/AnimatedIllustration'
-		)
-)
-
-const Illustration = () => (
-	<Suspense fallback={null}>
-		<LazyIllustration small={true} />
-	</Suspense>
-)
 
 export default () => {
 	const { t } = useTranslation()
@@ -29,17 +16,14 @@ export default () => {
 
 	return (
 		<div className={'ui__ container fluid'}>
-			<Meta title={title} description={description} />
+			<Meta
+				title={title}
+				description={description}
+				image="https://nosgestesclimat.fr/images/dessin-nosgestesclimat.png"
+			/>
 			<h1 data-cypress-id="blog-title">{title}</h1>
+			<p>{description}</p>
 
-			<div
-				css={`
-					text-align: center;
-				`}
-			>
-				<Illustration aria-hidden="true" />
-				<p>{description}</p>
-			</div>
 			<ScrollToTop />
 			<ul
 				css={`

--- a/source/sites/publicodes/pages/Blog.tsx
+++ b/source/sites/publicodes/pages/Blog.tsx
@@ -4,8 +4,21 @@ import { Link } from 'react-router-dom'
 
 import { ScrollToTop } from '@/components/utils/Scroll'
 import { getCurrentLangInfos } from '@/locales/translation'
+import React, { Suspense } from 'react'
 import { blogData } from './BlogData'
 import { dateCool, extractImage } from './news/NewsItem'
+const LazyIllustration = React.lazy(
+	() =>
+		import(
+			/* webpackChunkName: 'AnimatedIllustration' */ '@/components/AnimatedIllustration'
+		)
+)
+
+const Illustration = () => (
+	<Suspense fallback={null}>
+		<LazyIllustration small={true} />
+	</Suspense>
+)
 
 export default () => {
 	const { t } = useTranslation()
@@ -18,7 +31,15 @@ export default () => {
 		<div className={'ui__ container fluid'}>
 			<Meta title={title} description={description} />
 			<h1 data-cypress-id="blog-title">{title}</h1>
-			<p>{description}</p>
+
+			<div
+				css={`
+					text-align: center;
+				`}
+			>
+				<Illustration aria-hidden="true" />
+				<p>{description}</p>
+			</div>
 			<ScrollToTop />
 			<ul
 				css={`
@@ -56,6 +77,7 @@ export default () => {
 									height: 8rem;
 									margin-bottom: 0.6rem;
 								`}
+								alt={`Illustration: ${post.title}`}
 							/>
 							<div
 								css={`


### PR DESCRIPTION
Ajout d'une illustration pour le blog, pour fournir une vignette lors des partages automatique via linkedin par exemple.
Ajoute également un petit alt sur les vignettes des articles.