### PR TITLE
🐛 Passe la prop `isFromActionCard` manquante

### DIFF
--- a/source/actions/actions.ts
+++ b/source/actions/actions.ts
@@ -251,9 +251,7 @@ export const setSituationBranch = (id: number): Action => ({
 	id,
 })
 
-const setSimulation = (
-	simulation: Pick<Simulation, 'config' | 'url'>
-): AnyAction => ({
+const setSimulation = (simulation: Simulation): AnyAction => ({
 	type: 'SET_SIMULATION',
 	...simulation,
 })

--- a/source/actions/actions.ts
+++ b/source/actions/actions.ts
@@ -251,7 +251,9 @@ export const setSituationBranch = (id: number): Action => ({
 	id,
 })
 
-const setSimulation = (simulation: Simulation): AnyAction => ({
+const setSimulation = (
+	simulation: Partial<Simulation> | Simulation
+): AnyAction => ({
 	type: 'SET_SIMULATION',
 	...simulation,
 })
@@ -287,7 +289,7 @@ export const setSimulationConfig =
 		if (pastSimulationConfig === config) {
 			return
 		}
-		dispatch(setSimulation({ config, url: url || '' }))
+		dispatch(setSimulation({ config, url: url ?? '' }))
 		dispatch(addSimulationToList(getState().simulation))
 		dispatch(setCurrentSimulation(getState().simulation))
 	}

--- a/source/actions/actions.ts
+++ b/source/actions/actions.ts
@@ -8,6 +8,7 @@ import {
 	TutorialStateStatus,
 } from '@/reducers/rootReducer'
 import { Rating } from '@/selectors/storageSelectors'
+import { AnyAction } from 'redux'
 import { ThunkAction } from 'redux-thunk'
 
 /**
@@ -250,7 +251,9 @@ export const setSituationBranch = (id: number): Action => ({
 	id,
 })
 
-const setSimulation = (simulation: Simulation): Action => ({
+const setSimulation = (
+	simulation: Pick<Simulation, 'config' | 'url'>
+): AnyAction => ({
 	type: 'SET_SIMULATION',
 	...simulation,
 })
@@ -280,13 +283,13 @@ export const setCurrentSimulation = (simulation: Simulation): Action => ({
 })
 
 export const setSimulationConfig =
-	(config: SimulationConfig, url: string): ThunkResult<void> =>
-	(dispatch, getState, {}): void => {
+	(config: SimulationConfig, url?: string): ThunkResult =>
+	(dispatch, getState): void => {
 		const pastSimulationConfig = getState().simulation?.config
 		if (pastSimulationConfig === config) {
 			return
 		}
-		dispatch(setSimulation({ config, url }))
+		dispatch(setSimulation({ config, url: url || '' }))
 		dispatch(addSimulationToList(getState().simulation))
 		dispatch(setCurrentSimulation(getState().simulation))
 	}

--- a/source/components/publicodesUtils.tsx
+++ b/source/components/publicodesUtils.tsx
@@ -304,7 +304,7 @@ const categoryColorOverride = {
 
 export function extractCategories(
 	rules: any,
-	engine: Engine,
+	engine: Engine<DottedName>,
 	valuesFromURL?: any,
 	parentRule = MODEL_ROOT_RULE_NAME,
 	sort = true

--- a/source/reducers/rootReducer.ts
+++ b/source/reducers/rootReducer.ts
@@ -112,7 +112,7 @@ function simulation(
 
 			return {
 				config,
-				url,
+				url: url ?? state?.url ?? '',
 				hiddenNotifications: state?.hiddenControls ?? [], // todo : hiddenControls ?
 				situation: action.situation ?? state?.situation ?? {},
 				targetUnit: config['unité par défaut'] ?? '€/mois',

--- a/source/sites/publicodes/Action.tsx
+++ b/source/sites/publicodes/Action.tsx
@@ -30,7 +30,7 @@ export default () => {
 
 	const rules = useSelector((state: AppState) => state.rules)
 	const nextQuestions = useNextQuestions()
-	const dottedName = decodeRuleName(encodedName || '')
+	const dottedName = decodeRuleName(encodedName ?? '')
 	const configSet = useSelector((state: AppState) => state.simulation?.config)
 
 	// TODO here we need to apply a rustine to accommodate for this issue

--- a/source/sites/publicodes/Action.tsx
+++ b/source/sites/publicodes/Action.tsx
@@ -1,3 +1,4 @@
+import { setSimulationConfig } from '@/actions/actions'
 import {
 	DottedName,
 	NGCEvaluatedRuleNode,
@@ -11,7 +12,6 @@ import Meta from '@/components/utils/Meta'
 import { ScrollToTop } from '@/components/utils/Scroll'
 import { useNextQuestions } from '@/hooks/useNextQuestion'
 import { AppState } from '@/reducers/rootReducer'
-import { setSimulationConfig } from 'Actions/actions'
 import { utils } from 'publicodes'
 import { useContext, useEffect } from 'react'
 import emoji from 'react-easy-emoji'
@@ -23,14 +23,14 @@ import { questionConfig } from './questionConfig'
 
 const { decodeRuleName, encodeRuleName } = utils
 
-export default ({}) => {
+export default () => {
 	const encodedName = useParams()['*']
 
 	const { t } = useTranslation()
 
 	const rules = useSelector((state: AppState) => state.rules)
 	const nextQuestions = useNextQuestions()
-	const dottedName = decodeRuleName(encodedName)
+	const dottedName = decodeRuleName(encodedName || '')
 	const configSet = useSelector((state: AppState) => state.simulation?.config)
 
 	// TODO here we need to apply a rustine to accommodate for this issue
@@ -45,10 +45,14 @@ export default ({}) => {
 	const engine = useContext(EngineContext)
 
 	const dispatch = useDispatch()
+
 	useEffect(() => {
 		dispatch(setSimulationConfig(config))
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [encodedName])
-	if (!configSet) return null
+
+	if (!configSet || !engine) return null
 
 	const evaluation = engine.evaluate(dottedName) as NGCEvaluatedRuleNode
 	const { title } = evaluation
@@ -101,7 +105,7 @@ export default ({}) => {
 					</h2>
 				</header>
 				<div css="margin: 1.6rem 0">
-					<Markdown children={description ?? ''} />
+					<Markdown>{description ?? ''}</Markdown>
 					<div css="display: flex; flex-wrap: wrap; justify-content: space-evenly; margin-top: 1rem">
 						<Link to={'/documentation/' + encodedName}>
 							<button className="ui__ button small">
@@ -128,6 +132,7 @@ export default ({}) => {
 						conversationProps={{
 							customEnd: <div />,
 							questionHeadingLevel: 4,
+							isFromActionCard: true,
 						}}
 					/>
 				</>
@@ -138,8 +143,9 @@ export default ({}) => {
 						<Trans>Sur le même sujet</Trans>
 					</h3>
 					<div>
-						{relatedActions.map((action) => (
+						{relatedActions.map((action, index) => (
 							<Link
+								key={`relatedAction${index}`}
 								to={'/actions/' + encodeRuleName(action.dottedName)}
 								css="> button {margin: .3rem .6rem}"
 							>

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -346,7 +346,7 @@ const Router = () => {
 		<Routes>
 			<Route path="/" element={<Landing />} />
 			<Route
-				path="documentation/*"
+				path="/documentation/*"
 				element={
 					<WithEngine options={{ parsed: false, optimized: false }}>
 						<Suspense fallback={<AnimatedLoader />}>
@@ -356,7 +356,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path="questions"
+				path="/questions"
 				element={
 					<WithEngine options={{ parsed: true, optimized: false }}>
 						<Suspense fallback={<AnimatedLoader />}>
@@ -366,7 +366,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path={'modèle'}
+				path="/modèle"
 				element={
 					<Suspense fallback={<AnimatedLoader />}>
 						<ModelLazy />
@@ -374,7 +374,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path="simulateur/*"
+				path="/simulateur/*"
 				element={
 					<Suspense fallback={<AnimatedLoader />}>
 						<WithEngine>
@@ -487,7 +487,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path={'nouveautés/*'}
+				path="/nouveautés/*"
 				element={
 					<Suspense fallback={<AnimatedLoader />}>
 						<News />
@@ -495,7 +495,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path={'blog'}
+				path="/blog"
 				element={
 					<Suspense fallback={<AnimatedLoader />}>
 						<BlogLazy />
@@ -503,7 +503,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path={'blog/:slug'}
+				path="blog/:slug"
 				element={
 					<Suspense fallback={<AnimatedLoader />}>
 						<BlogArticleLazy />
@@ -527,7 +527,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path={'conférence/:room'}
+				path="/conférence/:room"
 				element={
 					<Suspense fallback={<AnimatedLoader />}>
 						<ConferenceLazy />
@@ -609,7 +609,7 @@ const Router = () => {
 				}
 			/>
 			<Route
-				path={'/northstar'}
+				path="/northstar"
 				element={
 					<Suspense fallback={<AnimatedLoader />}>
 						<NorthstarStatsLazy />


### PR DESCRIPTION
La redirection se faisait à cause d'une prop manquante dans `Action.tsx` qui déclenchait ce `useEffect` dans `Conversation.tsx` :

```
	useEffect(() => {
		// This hook lets the user click on the "next" button. Without it, the conversation
		// switches to the next question as soon as an answer is provided.
		// It introduces a state
		// It is important to test for "previousSimulation" : if it exists, it's not loaded yet.
		// Then currentQuestion could be the wrong one, already answered,
		// don't put it as the unfoldedStep
		if (
			currentQuestion &&
			!previousSimulation &&
			currentQuestion !== unfoldedStep
		) {
			goToQuestionOrNavigate({
				question: currentQuestion,
				simulateurRootURL: simulateurRootRuleURL,
				focusedCategory,
				// NOTE(@EmileRolley): Action card remaining questions are displayed inline, therefore,  we don't want
				// to trigger the [navigate] (or we must add url for action questions
				// which add not needed complexity for now).
				toUse: isFromActionCard ? { dispatch } : { navigate },
			})
		}
	}, [dispatch, currentQuestion, previousAnswers, unfoldedStep, objectifs])
```