### PR TITLE
Fix: go to specific question only if the test is completed

### DIFF
--- a/cypress/e2e/test-completion/questions-order.cy.js
+++ b/cypress/e2e/test-completion/questions-order.cy.js
@@ -55,11 +55,12 @@ describe('validate the question order behavior', () => {
 	})
 
 	it("should follow the question order (transports, alimentation, logement, divers, services publiques)", () => {
-      // Prevents https://github.com/datagir/nosgestesclimat-site/pull/1049 from happening again
-      // Questions where skipped when the value passed was too low
-      cy.get('main').contains('Transport')
-      cy.get('button.suggestion').first().click()
-      cy.get('button[data-cypress-id="next-question-button"]').first().click()
-      cy.get('main').contains('Transport')
+		// Prevents https://github.com/datagir/nosgestesclimat-site/pull/1049 from happening again
+		// Questions where skipped when the value passed was too low
+		cy.url().should('include', 'question=transport')
+		cy.get('button.suggestion').first().click()
+		cy.url().should('include', 'question=transport')
+		clickDontKnowButton()
+		cy.url().should('include', 'question=transport')
 	})
 })

--- a/cypress/e2e/test-completion/questions-order.cy.js
+++ b/cypress/e2e/test-completion/questions-order.cy.js
@@ -3,6 +3,7 @@ import {
 	clickCategoryStartButton,
 	clickDontKnowButton,
 	clickPreviousButton,
+	clickNextButton,
 	clickUnderstoodButton
 } from "./utils"
 
@@ -59,6 +60,7 @@ describe('validate the question order behavior', () => {
 		// Questions where skipped when the value passed was too low
 		cy.url().should('include', 'question=transport')
 		cy.get('button.suggestion').first().click()
+		clickNextButton()
 		cy.url().should('include', 'question=transport')
 		clickDontKnowButton()
 		cy.url().should('include', 'question=transport')

--- a/cypress/e2e/test-completion/questions-order.cy.js
+++ b/cypress/e2e/test-completion/questions-order.cy.js
@@ -2,7 +2,6 @@ import {
 	startTestAndSkipTutorial,
 	clickCategoryStartButton,
 	clickDontKnowButton,
-	clickPreviousButton,
 	clickNextButton,
 	clickUnderstoodButton
 } from "./utils"

--- a/cypress/e2e/test-completion/url-redirection.cy.js
+++ b/cypress/e2e/test-completion/url-redirection.cy.js
@@ -34,7 +34,10 @@ function shouldRedirectTo(entryPoint, expectedURL, category = mainSimulator) {
 	)
 }
 
-describe('check question redirection from the URL for the category "bilan" (with finished test)', () => {
+// NOTE(@EmileRolley): for now the URL redirection is disabled, so this tests are disabled too
+// however, they are still useful to check the redirection logic if we want to re-enable it.
+
+// describe('check question redirection from the URL for the category "bilan" (with finished test)', () => {
 	// it(`should redirect to the last question answered`, () => {
 	// 	cy.log('Skip tutorial and finish the test')
 	// 	cy.visit(`/`)
@@ -50,43 +53,43 @@ describe('check question redirection from the URL for the category "bilan" (with
 	// 	cy.url().should('eq', Cypress.config().baseUrl + `/simulateur/${mainSimulator}?question=${thirdQuestion}`)
 	// })
 
-	it(`should redirect to a question without space in the name`, () => {
-		cy.log('Skip tutorial and finish the test')
-		cy.visit(`/`)
-		startTestAndSkipTutorial()
-		walkthroughTest({})
-		clickSeeResultsLink()
-		cy.wait(2000)
-
-		cy.log('should redirect to a question without space in the name')
-		goToQuestionAndGet('logement.surface')
-
-		cy.log(`should redirect to a question with space in the name`)
-		goToQuestionAndGet('logement.saisie-habitants')
-
-		cy.log(`should redirect to a question with more than 2 depth in the name + space in it`)
-		goToQuestionAndGet('transport.avion.court-courrier.heures-de-vol')
-
-		cy.log(`should redirect to a mosaic question`)
-		goToQuestionAndGet('transport.vacances', 'bilan', '.camping-car.propriétaire')
-
-		cy.log(`should redirect to a question within a mosaic`)
-		shouldRedirectTo('transport.vacances.camping-car.propriétaire', 'transport.vacances')
-		shouldRedirectTo('transport.vacances.caravane.propriétaire', 'transport.vacances')
-
-		cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule`)
-		shouldRedirectTo(
-			'logement.appartement.unknown-rule.adaf.adf',
-			'logement.appartement'
-		)
-
-		cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule with a question`)
-		shouldRedirectTo(
-			'transport.voiture.motorisation.thermique',
-			'transport.voiture.motorisation'
-		)
-	})
-})
+	// it(`should redirect to a question without space in the name`, () => {
+	// 	cy.log('Skip tutorial and finish the test')
+	// 	cy.visit(`/`)
+	// 	startTestAndSkipTutorial()
+	// 	walkthroughTest({})
+	// 	clickSeeResultsLink()
+	// 	cy.wait(2000)
+	//
+	// 	cy.log('should redirect to a question without space in the name')
+	// 	goToQuestionAndGet('logement.surface')
+	//
+	// 	cy.log(`should redirect to a question with space in the name`)
+	// 	goToQuestionAndGet('logement.saisie-habitants')
+	//
+	// 	cy.log(`should redirect to a question with more than 2 depth in the name + space in it`)
+	// 	goToQuestionAndGet('transport.avion.court-courrier.heures-de-vol')
+	//
+	// 	cy.log(`should redirect to a mosaic question`)
+	// 	goToQuestionAndGet('transport.vacances', 'bilan', '.camping-car.propriétaire')
+	//
+	// 	cy.log(`should redirect to a question within a mosaic`)
+	// 	shouldRedirectTo('transport.vacances.camping-car.propriétaire', 'transport.vacances')
+	// 	shouldRedirectTo('transport.vacances.caravane.propriétaire', 'transport.vacances')
+	//
+	// 	cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule`)
+	// 	shouldRedirectTo(
+	// 		'logement.appartement.unknown-rule.adaf.adf',
+	// 		'logement.appartement'
+	// 	)
+	//
+	// 	cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule with a question`)
+	// 	shouldRedirectTo(
+	// 		'transport.voiture.motorisation.thermique',
+	// 		'transport.voiture.motorisation'
+	// 	)
+	// })
+// })
 
 // describe('check question redirection from the URL for sub-simulators', () => {
 // 	it(`should redirect to the first question of the sub-simulator /transport/avion`,

--- a/cypress/e2e/test-completion/url-redirection.cy.js
+++ b/cypress/e2e/test-completion/url-redirection.cy.js
@@ -1,12 +1,9 @@
 import {
-	clickUnderstoodButtonIfExist,
-	clickCategoryStartButtonIfExist,
-	clickSkipTutoButton,
-	clickUnderstoodButton,
-	clickCategoryStartButton,
 	walkthroughTest,
 	waitWhileLoading,
+	startTestAndSkipTutorial,
 	clickDontKnowButton,
+	clickCategoryStartButton
 } from './utils'
 
 const params =
@@ -15,6 +12,7 @@ const params =
 	""
 
 const firstQuestion = "transport.voiture.km"
+const thirdQuestion = "transport.voiture.motorisation"
 const mainSimulator = "bilan"
 
 function goToQuestionAndGet(
@@ -23,93 +21,92 @@ function goToQuestionAndGet(
 	mosaicFirstQuestion = '',
 ) {
 	cy.visit(`/simulateur/${rootSimulatorURL}?question=${question}`)
-	clickUnderstoodButtonIfExist()
-
 	waitWhileLoading()
-	clickCategoryStartButton()
 	cy.get(`[id="id-question-${question}${mosaicFirstQuestion}"]`)
 }
 
 function shouldRedirectTo(entryPoint, expectedURL, category = mainSimulator) {
 	cy.visit(`/simulateur/${category}?question=${entryPoint}`)
-	if (category === mainSimulator && expectedURL === firstQuestion) {
-		clickSkipTutoButton()
-	}
-	clickUnderstoodButtonIfExist()
-	clickCategoryStartButtonIfExist()
 	cy.url().should('eq',
 		Cypress.config().baseUrl
 		+ `/simulateur/${category}${expectedURL ? `?question=${expectedURL}` : ''}`
 	)
 }
 
-describe('check question redirection from the URL for the category "bilan"', () => {
-	it(`should redirect to a question without space in the name`, () => {
-		goToQuestionAndGet('logement.surface')
-	})
+describe('check question redirection from the URL for the category "bilan" (with finished test)', () => {
 
-	it(`tutorial should be displayed when going to root after having visited a specific rule URL`, () => {
-		goToQuestionAndGet('logement.surface')
-		cy.visit(`/simulateur/bilan`)
-		clickSkipTutoButton()
-	})
+	it(`should redirect to the last question answered`, () => {
+		cy.log('Skip tutorial and finish the test')
+		cy.visit(`/`)
+		startTestAndSkipTutorial()
 
-	it(`should redirect to a question with space in the name`, () => {
-		goToQuestionAndGet('logement.saisie-habitants')
-	})
-
-	it(`should redirect to a question with more than 2 depth in the name + space in it`, () => {
-		goToQuestionAndGet('transport.avion.court-courrier.heures-de-vol')
-	})
-
-	it(`should redirect to a mosaic question`, () => {
-		goToQuestionAndGet('transport.vacances', 'bilan', '.camping-car.propriétaire')
-	})
-
-	it(`should redirect to a question within a mosaic`, () => {
-		shouldRedirectTo('transport.vacances.camping-car.propriétaire', 'transport.vacances')
-		shouldRedirectTo('transport.vacances.caravane.propriétaire', 'transport.vacances')
-	})
-
-	it(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule`,
-	  () => {
-			shouldRedirectTo('logement.unknown-rule', firstQuestion)
-			shouldRedirectTo(
-				'logement.appartement.unknown-rule.adaf.adf',
-				'logement.appartement'
-			)
+		for (let i = 0; i < 3; i++) {
+				clickDontKnowButton()
 		}
-	)
 
-	it(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule with a question`, () => {
-		shouldRedirectTo(
-			'transport.voiture.motorisation.thermique',
-			'transport.voiture.motorisation'
-		)
+		cy.url().should('eq', Cypress.config().baseUrl + `/simulateur/${mainSimulator}?question=${thirdQuestion}`)
+		cy.wait(1000)
+		cy.visit(`/simulateur/${mainSimulator}?question=logement.surface`)
+		cy.url().should('eq', Cypress.config().baseUrl + `/simulateur/${mainSimulator}?question=${thirdQuestion}`)
 	})
+
+	// it(`should redirect to a question without space in the name`, () => {
+	// 	cy.log('Skip tutorial and finish the test')
+	// 	cy.visit(`/`)
+	// 	startTestAndSkipTutorial()
+	// 	walkthroughTest({})
+	//
+	// 	cy.log('should redirect to a question without space in the name')
+	// 	goToQuestionAndGet('logement.surface')
+	//
+	// 	cy.log(`should redirect to a question with space in the name`)
+	// 	goToQuestionAndGet('logement.saisie-habitants')
+	//
+	// 	cy.log(`should redirect to a question with more than 2 depth in the name + space in it`)
+	// 	goToQuestionAndGet('transport.avion.court-courrier.heures-de-vol')
+	//
+	// 	cy.log(`should redirect to a mosaic question`)
+	// 	goToQuestionAndGet('transport.vacances', 'bilan', '.camping-car.propriétaire')
+	//
+	// 	cy.log(`should redirect to a question within a mosaic`)
+	// 	shouldRedirectTo('transport.vacances.camping-car.propriétaire', 'transport.vacances')
+	// 	shouldRedirectTo('transport.vacances.caravane.propriétaire', 'transport.vacances')
+	//
+	// 	cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule`)
+	// 	shouldRedirectTo(
+	// 		'logement.appartement.unknown-rule.adaf.adf',
+	// 		'logement.appartement'
+	// 	)
+	//
+	// 	cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule with a question`)
+	// 	shouldRedirectTo(
+	// 		'transport.voiture.motorisation.thermique',
+	// 		'transport.voiture.motorisation'
+	// 	)
+	// })
 })
 
-describe('check question redirection from the URL for sub-simulators', () => {
-	it(`should redirect to the first question of the sub-simulator /transport/avion`,
-		() => {
-			cy.visit(`/simulateur/transport/avion`)
-			cy.get(`[id="id-question-transport.avion.usager"]`)
-		}
-	)
-
-	it(`should redirect to the first question of the sub-simulator /transport/avion`,
-		() => {
-			cy.visit(`/simulateur/divers/produits-consommables`)
-			cy.get(`[id="id-question-divers.produits-consommables.consommation"]`)
-		}
-	)
-
-	it(`should arrive to the simulation ending page when the last question is answered`,
-		() => {
-			cy.visit(`/simulateur/transport/avion`)
-			cy.get(`[id="id-question-transport.avion.usager"]`)
-			walkthroughTest({})
-			cy.get(`[data-cypress-id="simulation-ending"`)
-		}
-	)
-})
+// describe('check question redirection from the URL for sub-simulators', () => {
+// 	it(`should redirect to the first question of the sub-simulator /transport/avion`,
+// 		() => {
+// 			cy.visit(`/simulateur/transport/avion`)
+// 			cy.get(`[id="id-question-transport.avion.usager"]`)
+// 		}
+// 	)
+//
+// 	it(`should redirect to the first question of the sub-simulator /transport/avion`,
+// 		() => {
+// 			cy.visit(`/simulateur/divers/produits-consommables`)
+// 			cy.get(`[id="id-question-divers.produits-consommables.consommation"]`)
+// 		}
+// 	)
+//
+// 	it(`should arrive to the simulation ending page when the last question is answered`,
+// 		() => {
+// 			cy.visit(`/simulateur/transport/avion`)
+// 			cy.get(`[id="id-question-transport.avion.usager"]`)
+// 			walkthroughTest({})
+// 			cy.get(`[data-cypress-id="simulation-ending"`)
+// 		}
+// 	)
+// })

--- a/cypress/e2e/test-completion/url-redirection.cy.js
+++ b/cypress/e2e/test-completion/url-redirection.cy.js
@@ -4,17 +4,10 @@ import {
 	startTestAndSkipTutorial,
 	clickDontKnowButton,
 	clickCategoryStartButton,
-	clickSeeResultsLink
+	clickSeeResultsLink,
+	skipTutoIfExists,
+	clickSkipTutoButton
 } from './utils'
-
-// ============================================================================
-//
-// NOTE(@EmileRolley): for now the URL redirection is disabled, so this tests
-// are disabled too. However, they are still useful to check the redirection
-// logic if we want to re-enable it.
-//
-// ============================================================================
-
 
 const params =
 	// `loc=${Cypress.env('localisation_param')}&lang=${Cypress.env('language_param')}`
@@ -42,6 +35,48 @@ function shouldRedirectTo(entryPoint, expectedURL, category = mainSimulator) {
 		+ `/simulateur/${category}${expectedURL ? `?question=${expectedURL}` : ''}`
 	)
 }
+
+describe('check redirection when an unknow rule is specified for the simulator root rule to use', () => {
+	it(`should redirect to 'bilan'`, () => {
+		cy.visit(`/simulateur/unknown`)
+		cy.wait(1000)
+		clickSkipTutoButton()
+		cy.url().should('includes', Cypress.config().baseUrl + `/simulateur/${mainSimulator}`)
+	})
+})
+
+describe('check question redirection from the URL for sub-simulators', () => {
+	it(`should redirect to the first question of the sub-simulator /transport/avion`,
+		() => {
+			cy.visit(`/simulateur/transport/avion`)
+			cy.get(`[id="id-question-transport.avion.usager"]`)
+		}
+	)
+
+	it(`should redirect to the first question of the sub-simulator /transport/avion`,
+		() => {
+			cy.visit(`/simulateur/divers/produits-consommables`)
+			cy.get(`[id="id-question-divers.produits-consommables.consommation"]`)
+		}
+	)
+
+	it(`should arrive to the simulation ending page when the last question is answered`,
+		() => {
+			cy.visit(`/simulateur/transport/avion`)
+			cy.get(`[id="id-question-transport.avion.usager"]`)
+			walkthroughTest({})
+			cy.get(`[data-cypress-id="simulation-ending"`)
+		}
+	)
+})
+
+// ============================================================================
+//
+// NOTE(@EmileRolley): for now the URL redirection is disabled, so this tests
+// are disabled too. However, they are still useful to check the redirection
+// logic if we want to re-enable it.
+//
+// ============================================================================
 
 // describe('check question redirection from the URL for the category "bilan" (with finished test)', () => {
 	// it(`should redirect to the last question answered`, () => {
@@ -95,29 +130,4 @@ function shouldRedirectTo(entryPoint, expectedURL, category = mainSimulator) {
 	// 		'transport.voiture.motorisation'
 	// 	)
 	// })
-// })
-
-// describe('check question redirection from the URL for sub-simulators', () => {
-// 	it(`should redirect to the first question of the sub-simulator /transport/avion`,
-// 		() => {
-// 			cy.visit(`/simulateur/transport/avion`)
-// 			cy.get(`[id="id-question-transport.avion.usager"]`)
-// 		}
-// 	)
-//
-// 	it(`should redirect to the first question of the sub-simulator /transport/avion`,
-// 		() => {
-// 			cy.visit(`/simulateur/divers/produits-consommables`)
-// 			cy.get(`[id="id-question-divers.produits-consommables.consommation"]`)
-// 		}
-// 	)
-//
-// 	it(`should arrive to the simulation ending page when the last question is answered`,
-// 		() => {
-// 			cy.visit(`/simulateur/transport/avion`)
-// 			cy.get(`[id="id-question-transport.avion.usager"]`)
-// 			walkthroughTest({})
-// 			cy.get(`[data-cypress-id="simulation-ending"`)
-// 		}
-// 	)
 // })

--- a/cypress/e2e/test-completion/url-redirection.cy.js
+++ b/cypress/e2e/test-completion/url-redirection.cy.js
@@ -3,7 +3,8 @@ import {
 	waitWhileLoading,
 	startTestAndSkipTutorial,
 	clickDontKnowButton,
-	clickCategoryStartButton
+	clickCategoryStartButton,
+	clickSeeResultsLink
 } from './utils'
 
 const params =
@@ -34,56 +35,57 @@ function shouldRedirectTo(entryPoint, expectedURL, category = mainSimulator) {
 }
 
 describe('check question redirection from the URL for the category "bilan" (with finished test)', () => {
-
-	it(`should redirect to the last question answered`, () => {
-		cy.log('Skip tutorial and finish the test')
-		cy.visit(`/`)
-		startTestAndSkipTutorial()
-
-		for (let i = 0; i < 3; i++) {
-				clickDontKnowButton()
-		}
-
-		cy.url().should('eq', Cypress.config().baseUrl + `/simulateur/${mainSimulator}?question=${thirdQuestion}`)
-		cy.wait(1000)
-		cy.visit(`/simulateur/${mainSimulator}?question=logement.surface`)
-		cy.url().should('eq', Cypress.config().baseUrl + `/simulateur/${mainSimulator}?question=${thirdQuestion}`)
-	})
-
-	// it(`should redirect to a question without space in the name`, () => {
+	// it(`should redirect to the last question answered`, () => {
 	// 	cy.log('Skip tutorial and finish the test')
 	// 	cy.visit(`/`)
 	// 	startTestAndSkipTutorial()
-	// 	walkthroughTest({})
 	//
-	// 	cy.log('should redirect to a question without space in the name')
-	// 	goToQuestionAndGet('logement.surface')
+	// 	for (let i = 0; i < 3; i++) {
+	// 			clickDontKnowButton()
+	// 	}
 	//
-	// 	cy.log(`should redirect to a question with space in the name`)
-	// 	goToQuestionAndGet('logement.saisie-habitants')
-	//
-	// 	cy.log(`should redirect to a question with more than 2 depth in the name + space in it`)
-	// 	goToQuestionAndGet('transport.avion.court-courrier.heures-de-vol')
-	//
-	// 	cy.log(`should redirect to a mosaic question`)
-	// 	goToQuestionAndGet('transport.vacances', 'bilan', '.camping-car.propriétaire')
-	//
-	// 	cy.log(`should redirect to a question within a mosaic`)
-	// 	shouldRedirectTo('transport.vacances.camping-car.propriétaire', 'transport.vacances')
-	// 	shouldRedirectTo('transport.vacances.caravane.propriétaire', 'transport.vacances')
-	//
-	// 	cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule`)
-	// 	shouldRedirectTo(
-	// 		'logement.appartement.unknown-rule.adaf.adf',
-	// 		'logement.appartement'
-	// 	)
-	//
-	// 	cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule with a question`)
-	// 	shouldRedirectTo(
-	// 		'transport.voiture.motorisation.thermique',
-	// 		'transport.voiture.motorisation'
-	// 	)
+	// 	cy.url().should('eq', Cypress.config().baseUrl + `/simulateur/${mainSimulator}?question=${thirdQuestion}`)
+	// 	cy.wait(1000)
+	// 	cy.visit(`/simulateur/${mainSimulator}?question=logement.surface`)
+	// 	cy.url().should('eq', Cypress.config().baseUrl + `/simulateur/${mainSimulator}?question=${thirdQuestion}`)
 	// })
+
+	it(`should redirect to a question without space in the name`, () => {
+		cy.log('Skip tutorial and finish the test')
+		cy.visit(`/`)
+		startTestAndSkipTutorial()
+		walkthroughTest({})
+		clickSeeResultsLink()
+		cy.wait(2000)
+
+		cy.log('should redirect to a question without space in the name')
+		goToQuestionAndGet('logement.surface')
+
+		cy.log(`should redirect to a question with space in the name`)
+		goToQuestionAndGet('logement.saisie-habitants')
+
+		cy.log(`should redirect to a question with more than 2 depth in the name + space in it`)
+		goToQuestionAndGet('transport.avion.court-courrier.heures-de-vol')
+
+		cy.log(`should redirect to a mosaic question`)
+		goToQuestionAndGet('transport.vacances', 'bilan', '.camping-car.propriétaire')
+
+		cy.log(`should redirect to a question within a mosaic`)
+		shouldRedirectTo('transport.vacances.camping-car.propriétaire', 'transport.vacances')
+		shouldRedirectTo('transport.vacances.caravane.propriétaire', 'transport.vacances')
+
+		cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule`)
+		shouldRedirectTo(
+			'logement.appartement.unknown-rule.adaf.adf',
+			'logement.appartement'
+		)
+
+		cy.log(`should redirect to the first existing parent rule if the URL doesn't correspond to a parsed rule with a question`)
+		shouldRedirectTo(
+			'transport.voiture.motorisation.thermique',
+			'transport.voiture.motorisation'
+		)
+	})
 })
 
 // describe('check question redirection from the URL for sub-simulators', () => {

--- a/cypress/e2e/test-completion/url-redirection.cy.js
+++ b/cypress/e2e/test-completion/url-redirection.cy.js
@@ -7,6 +7,15 @@ import {
 	clickSeeResultsLink
 } from './utils'
 
+// ============================================================================
+//
+// NOTE(@EmileRolley): for now the URL redirection is disabled, so this tests
+// are disabled too. However, they are still useful to check the redirection
+// logic if we want to re-enable it.
+//
+// ============================================================================
+
+
 const params =
 	// `loc=${Cypress.env('localisation_param')}&lang=${Cypress.env('language_param')}`
 	// FIXME: seems to be broken with the localisation param
@@ -33,9 +42,6 @@ function shouldRedirectTo(entryPoint, expectedURL, category = mainSimulator) {
 		+ `/simulateur/${category}${expectedURL ? `?question=${expectedURL}` : ''}`
 	)
 }
-
-// NOTE(@EmileRolley): for now the URL redirection is disabled, so this tests are disabled too
-// however, they are still useful to check the redirection logic if we want to re-enable it.
 
 // describe('check question redirection from the URL for the category "bilan" (with finished test)', () => {
 	// it(`should redirect to the last question answered`, () => {

--- a/cypress/e2e/test-completion/utils.js
+++ b/cypress/e2e/test-completion/utils.js
@@ -49,6 +49,10 @@ export async function clickNextButton() {
 	cy.get('[data-cypress-id="next-question-button"]').click()
 }
 
+export async function clickSeeResultsLink() {
+	cy.get('[data-cypress-id="see-results-link"]').click()
+}
+
 export async function startTestAndSkipTutorial() {
 	cy.get('[data-cypress-id="do-the-test-link"]').click()
 	waitWhileLoading()

--- a/scripts/generateSitemap.ts
+++ b/scripts/generateSitemap.ts
@@ -4,7 +4,7 @@ import Engine, { utils } from 'publicodes'
 import {
 	DottedName,
 	encodeRuleNameToSearchParam,
-	isValidRule,
+	isValidQuestion,
 	NGCRulesNodes,
 } from '../source/components/publicodesUtils'
 
@@ -73,7 +73,7 @@ fetch('https://data.nosgestesclimat.fr/co2-model.FR-lang.fr.json')
 
 		const parsedRules = new Engine(json).getParsedRules() as NGCRulesNodes
 		const questionURLs = ruleNames
-			.filter((dottedName) => isValidRule(dottedName, parsedRules))
+			.filter((dottedName) => isValidQuestion(dottedName, parsedRules))
 			.map(
 				(dottedName) =>
 					`https://nosgestesclimat.fr/simulateur/bilan?question=${encodeRuleNameToSearchParam(

--- a/source/actions/actions.ts
+++ b/source/actions/actions.ts
@@ -9,6 +9,7 @@ import {
 import { Rating } from '@/selectors/storageSelectors'
 import { AnyAction } from 'redux'
 import { ThunkAction } from 'redux-thunk'
+import { Value } from '../components/conversation/RuleInput'
 
 /**
  * The type of the actions that can be dispatched in the app.
@@ -92,8 +93,8 @@ type DeleteSimulationByIdAction = {
 
 type UpdateSituationAction = {
 	type: 'UPDATE_SITUATION'
-	fieldName: DottedName
-	value: unknown
+	fieldName: DottedName | null
+	value: Value
 }
 
 type LoadPreviousSimulationAction = {
@@ -304,8 +305,8 @@ export const deleteSimulationById = (id: string): Action => ({
 })
 
 export const updateSituation = (
-	fieldName: DottedName,
-	value: unknown
+	fieldName: DottedName | null,
+	value: Value
 ): Action => ({
 	type: 'UPDATE_SITUATION',
 	fieldName,

--- a/source/actions/actions.ts
+++ b/source/actions/actions.ts
@@ -1,3 +1,4 @@
+import { Value } from '@/components/conversation/RuleInput'
 import { Localisation } from '@/components/localisation/utils'
 import { DottedName } from '@/components/publicodesUtils'
 import {
@@ -7,9 +8,7 @@ import {
 	StoredTrajets,
 } from '@/reducers/rootReducer'
 import { Rating } from '@/selectors/storageSelectors'
-import { AnyAction } from 'redux'
 import { ThunkAction } from 'redux-thunk'
-import { Value } from '../components/conversation/RuleInput'
 
 /**
  * The type of the actions that can be dispatched in the app.
@@ -55,7 +54,7 @@ export type Action =
 	| ResetLocalisationAction
 	| UpdateAmortissementAvionAction
 
-export type ThunkResult<R = void> = ThunkAction<R, AppState, {}, Action>
+export type ThunkResult<R = void> = ThunkAction<R, AppState, object, Action>
 
 type StepAction = {
 	type: 'STEP_ACTION'
@@ -65,7 +64,7 @@ type StepAction = {
 
 type SetSimulationAction = {
 	type: 'SET_SIMULATION'
-} & Simulation
+} & Partial<Simulation>
 
 type SetCurrentSimulationAction = {
 	type: 'SET_CURRENT_SIMULATION'
@@ -201,7 +200,7 @@ type ResetLocalisationAction = {
 type UpdateAmortissementAvionAction = {
 	type: 'SET_AMORTISSEMENT'
 	// TODO(@EmileRolley): type this
-	amortissementAvionObject: Object
+	amortissementAvionObject: object
 }
 
 export const resetSimulation = (): Action => ({
@@ -238,7 +237,6 @@ export const validateWithDefaultValue =
 	(dottedName: DottedName): ThunkResult<void> =>
 	(dispatch) => {
 		dispatch(updateSituation(dottedName, undefined))
-		console.log('validateWithDefaultValue', dottedName)
 		dispatch({
 			type: 'STEP_ACTION',
 			name: 'fold',
@@ -251,9 +249,7 @@ export const setSituationBranch = (id: number): Action => ({
 	id,
 })
 
-const setSimulation = (
-	simulation: Partial<Simulation> | Simulation
-): AnyAction => ({
+const setSimulation = (simulation: Partial<Simulation>): Action => ({
 	type: 'SET_SIMULATION',
 	...simulation,
 })
@@ -313,7 +309,7 @@ export const updateSituation = (
 	value,
 })
 
-export const skipTutorial = (id: string, unskip: boolean = false): Action => ({
+export const skipTutorial = (id: string, unskip = false): Action => ({
 	type: 'SKIP_TUTORIAL',
 	id,
 	unskip,
@@ -391,7 +387,7 @@ export const resetLocalisation = (): Action => ({
 })
 
 export const updateAmortissementAvion = (
-	amortissementAvionObject: Object
+	amortissementAvionObject: object
 ): Action => ({
 	type: 'SET_AMORTISSEMENT',
 	amortissementAvionObject,

--- a/source/actions/actions.ts
+++ b/source/actions/actions.ts
@@ -237,6 +237,7 @@ export const validateWithDefaultValue =
 	(dottedName: DottedName): ThunkResult<void> =>
 	(dispatch) => {
 		dispatch(updateSituation(dottedName, undefined))
+		console.log('validateWithDefaultValue', dottedName)
 		dispatch({
 			type: 'STEP_ACTION',
 			name: 'fold',

--- a/source/actions/actions.ts
+++ b/source/actions/actions.ts
@@ -5,7 +5,6 @@ import {
 	Simulation,
 	SimulationConfig,
 	StoredTrajets,
-	TutorialStateStatus,
 } from '@/reducers/rootReducer'
 import { Rating } from '@/selectors/storageSelectors'
 import { AnyAction } from 'redux'
@@ -159,7 +158,6 @@ type SkipTutorialAction = {
 	type: 'SKIP_TUTORIAL'
 	id: string
 	unskip: boolean
-	fromRule?: TutorialStateStatus
 }
 
 type SetTrackingVariableAction = {
@@ -313,15 +311,10 @@ export const updateSituation = (
 	value,
 })
 
-export const skipTutorial = (
-	id: string,
-	unskip: boolean = false,
-	fromRule?: TutorialStateStatus
-): Action => ({
+export const skipTutorial = (id: string, unskip: boolean = false): Action => ({
 	type: 'SKIP_TUTORIAL',
 	id,
 	unskip,
-	fromRule,
 })
 
 export const setTrackingVariable = (name: string, value: boolean): Action => ({

--- a/source/components/Simulation.tsx
+++ b/source/components/Simulation.tsx
@@ -13,6 +13,7 @@ type SimulationProps = {
 	animation?: keyof typeof animate
 	conversationProps: Partial<ConversationProps>
 }
+
 export default function Simulation({
 	explanations,
 	results,

--- a/source/components/conversation/CategoryRespiration.tsx
+++ b/source/components/conversation/CategoryRespiration.tsx
@@ -47,7 +47,7 @@ export default ({ dismiss, questionCategory }) => {
 
 	const { trackEvent } = useContext(MatomoContext)
 
-	useKeypress('Enter', false, dismiss, 'keyup', [])
+	useKeypress('Escape', false, dismiss, 'keyup', [])
 
 	return (
 		<motion.section

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -18,6 +18,7 @@ import CategoryRespiration from '@/components/conversation/CategoryRespiration'
 import '@/components/conversation/conversation.css'
 import {
 	focusByCategory,
+	getMosaicParentRuleName,
 	getPreviousQuestion,
 	sortQuestionsByCategory,
 	updateCurrentURL,
@@ -34,6 +35,7 @@ import {
 	DottedName,
 	encodeRuleNameToSearchParam,
 	getRelatedMosaicInfosIfExists,
+	isMosaicChild,
 	isRootRule,
 	MODEL_ROOT_RULE_NAME,
 	NGCRulesNodes,
@@ -56,8 +58,8 @@ import {
 	objectifsSelector,
 	situationSelector,
 } from '@/selectors/simulationSelectors'
+import { enquêteSelector } from '@/sites/publicodes/enquête/enquêteSelector'
 import { useQuery } from '@/utils'
-import { enquêteSelector } from 'Enquête/enquêteSelector'
 import { motion } from 'framer-motion'
 import { utils } from 'publicodes'
 import React, { useContext, useEffect, useRef, useState } from 'react'
@@ -419,9 +421,13 @@ export default function Conversation({
 			focusedCategory,
 		})
 	} else if (currentQuestion) {
+		const isMosaicChildRuleName = isMosaicChild(rules, currentQuestion)
+
 		updateCurrentURL({
 			paramName: 'question',
-			paramValue: currentQuestion,
+			paramValue: isMosaicChildRuleName
+				? getMosaicParentRuleName(rules, currentQuestion)
+				: currentQuestion,
 			simulateurRootRuleURL,
 			focusedCategory,
 		})

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -62,7 +62,7 @@ import { enquêteSelector } from '@/sites/publicodes/enquête/enquêteSelector'
 import { useQuery } from '@/utils'
 import { motion } from 'framer-motion'
 import { utils } from 'publicodes'
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link, useLocation } from 'react-router-dom'
@@ -206,6 +206,16 @@ export default function Conversation({
 	const isMosaicSelection =
 		isAnsweredMosaic && mosaicParams['type'] === 'selection'
 
+	// NOTE(@EmileRolley): we need to useMemo here to avoid errors with useEffects that
+	// depends on questionsToSubmit.
+	const questionsToSubmit = useMemo(
+		() =>
+			isMosaic
+				? mosaicDottedNames?.map(([dottedName]) => dottedName)
+				: [currentQuestion],
+		[currentQuestion, isMosaic, mosaicDottedNames]
+	)
+
 	useEffect(() => {
 		// This hook enables to set all the checkbox of a mosaic to false once one is checked
 		if (isMosaicSelection) {
@@ -254,10 +264,6 @@ export default function Conversation({
 		mosaicRule?.dottedName,
 		dispatch,
 	])
-
-	const questionsToSubmit = isMosaic
-		? mosaicDottedNames?.map(([dottedName]) => dottedName)
-		: [currentQuestion]
 
 	const currentQuestionIndex = previousAnswers.findIndex(
 		(a) => a === unfoldedStep

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -73,6 +73,7 @@ export type ConversationProps = {
 	customEnd?: React.ReactNode
 	orderByCategories?: Category[]
 	questionHeadingLevel?: number
+	isFromActionCard?: boolean
 }
 
 export default function Conversation({
@@ -80,6 +81,7 @@ export default function Conversation({
 	customEnd,
 	orderByCategories,
 	questionHeadingLevel,
+	isFromActionCard,
 }: ConversationProps) {
 	const dispatch = useDispatch()
 	const engine = useContext(EngineContext)
@@ -393,7 +395,7 @@ export default function Conversation({
 		}
 	}, [noQuestionsLeft, bilan, trackEvent, endEventFired, isPersona])
 
-	if (noQuestionsLeft) {
+	if (!isFromActionCard && noQuestionsLeft) {
 		updateCurrentURL({
 			paramName: respirationParamName,
 			paramValue: 'congrats',
@@ -420,14 +422,14 @@ export default function Conversation({
 		isCategoryFirstQuestion &&
 		!tutorials['testCategory-' + questionCategory.dottedName]
 
-	if (displayRespiration) {
+	if (!isFromActionCard && displayRespiration) {
 		updateCurrentURL({
 			paramName: respirationParamName,
 			paramValue: questionCategory.dottedName,
 			simulateurRootRuleURL,
 			focusedCategory,
 		})
-	} else if (currentQuestion) {
+	} else if (!isFromActionCard && currentQuestion) {
 		const isMosaicChildRuleName = isMosaicChild(rules, currentQuestion)
 
 		updateCurrentURL({

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -59,6 +59,7 @@ import {
 	situationSelector,
 } from '@/selectors/simulationSelectors'
 import { enquêteSelector } from '@/sites/publicodes/enquête/enquêteSelector'
+import { respirationParamName } from '@/sites/publicodes/Simulateur'
 import { useQuery } from '@/utils'
 import { motion } from 'framer-motion'
 import { utils } from 'publicodes'
@@ -394,7 +395,7 @@ export default function Conversation({
 
 	if (noQuestionsLeft) {
 		updateCurrentURL({
-			paramName: 'respiration',
+			paramName: respirationParamName,
 			paramValue: 'congrats',
 			simulateurRootRuleURL,
 			focusedCategory,
@@ -421,7 +422,7 @@ export default function Conversation({
 
 	if (displayRespiration) {
 		updateCurrentURL({
-			paramName: 'respiration',
+			paramName: respirationParamName,
 			paramValue: questionCategory.dottedName,
 			simulateurRootRuleURL,
 			focusedCategory,

--- a/source/components/conversation/MosaicInputSuggestions.tsx
+++ b/source/components/conversation/MosaicInputSuggestions.tsx
@@ -8,6 +8,7 @@ type InputSuggestionsProps = {
 	dottedName: string
 	relatedRuleNames: Array<string>
 	suggestions?: Record<string, ASTNode>
+	mosaicType: 'selection' | 'nombre'
 }
 
 export default function MosaicInputSuggestions({
@@ -74,9 +75,9 @@ export default function MosaicInputSuggestions({
 							if (
 								Object.values(values).every((bool) => bool === 'non') ||
 								String(values) === 'aucun'
-							)
+							) {
 								dispatch(updateSituation(dottedName, 0))
-							else
+							} else {
 								Object.entries(values).forEach(
 									([ruleName, value]: [string, ASTNode]) => {
 										const fullDottedName = `${dottedName} . ${ruleName}`
@@ -93,10 +94,11 @@ export default function MosaicInputSuggestions({
 										dispatch(updateSituation(fullDottedName, value))
 									}
 								)
+							}
 						}}
 						title={t('Insérer cette suggestion')}
 					>
-						{emoji(t(('aucun' === text ? 'Aucun' : text)))}
+						{emoji(t('aucun' === text ? 'Aucun' : text))}
 					</button>
 				)
 			})}

--- a/source/components/conversation/RuleInput.tsx
+++ b/source/components/conversation/RuleInput.tsx
@@ -5,6 +5,7 @@ import PercentageField from '@/components/PercentageField'
 import {
 	DottedName,
 	getRelatedMosaicInfosIfExists,
+	NGCRulesNodes,
 	parentName,
 	splitName,
 	SuggestionsNode,
@@ -30,7 +31,8 @@ import NumberedMosaic from './select/NumberedMosaic'
 import SelectDevices from './select/SelectDevices'
 import TextInput from './TextInput'
 
-type Value = any
+export type Value = any
+
 export type RuleInputProps = {
 	dottedName: DottedName
 	onChange: (value: Value | null) => void
@@ -85,7 +87,7 @@ export default function RuleInput({
 	noSuggestions = false,
 }: RuleInputProps) {
 	const { t } = useTranslation()
-	const engine = givenEngine || useContext(EngineContext) //related to Survey Context : we enable the engine to be different according to the simulation rules we are working with.
+	const engine = givenEngine ?? useContext(EngineContext) //related to Survey Context : we enable the engine to be different according to the simulation rules we are working with.
 	const rule = engine.getRule(dottedName)
 	const evaluation = engine.evaluate(dottedName)
 	const rules = engine.getParsedRules() as NGCRulesNodes
@@ -125,6 +127,7 @@ export default function RuleInput({
 		// and the active ones are ordered as the `somme` defined as model side if the formula in the rule mosaic is a `somme`.
 		const orderedSumFromSourceRule =
 			question?.rawNode?.formule && question?.rawNode?.formule['somme']
+
 		if (orderedSumFromSourceRule) {
 			selectedRules.sort((a, b) => {
 				const indexA = orderedSumFromSourceRule.indexOf(
@@ -136,47 +139,54 @@ export default function RuleInput({
 				return indexA - indexB
 			})
 		}
-		if (mosaicParams['type'] === 'selection')
-			return (
-				<SelectDevices
-					{...{
-						...commonProps,
-						dottedName: question.dottedName,
-						selectedRules,
-						options:
-							// NOTE(@EmileRolley): where this options come from? And what is it?
-							// @ts-ignore
-							question.options ?? {},
-						suggestions: mosaicParams['suggestions'] || {},
-					}}
-				/>
-			)
-		if (mosaicParams['type'] === 'nombre')
-			return (
-				<NumberedMosaic
-					{...{
-						...commonProps,
-						dottedName: question.dottedName,
-						selectedRules,
-						options: { chipsTotal: mosaicParams['total'] } || {},
-						suggestions: mosaicParams['suggestions'] || {},
-					}}
-				/>
-			)
-		return
+
+		switch (mosaicParams['type']) {
+			case 'selection': {
+				console.log('DEBUG === mosaicParams', mosaicParams)
+				debugger
+				return (
+					<SelectDevices
+						{...{
+							...commonProps,
+							dottedName: question.dottedName,
+							selectedRules,
+							options:
+								// NOTE(@EmileRolley): where this options come from? And what is it?
+								// @ts-ignore
+								question.options ?? {},
+							suggestions: mosaicParams['suggestions'] ?? {},
+						}}
+					/>
+				)
+			}
+			case 'nombre': {
+				return (
+					<NumberedMosaic
+						{...{
+							...commonProps,
+							dottedName: question.dottedName,
+							selectedRules,
+							options: { chipsTotal: mosaicParams['total'] } ?? {},
+							suggestions: mosaicParams['suggestions'] ?? {},
+						}}
+					/>
+				)
+			}
+			default:
+				return null
+		}
 	}
 
 	if (isTransportEstimation(rule.dottedName)) {
 		const question = isTransportEstimation(rule.dottedName)
 		const unité = serializeUnit(evaluation.unit)
+
 		return (
 			<question.component
 				commonProps={commonProps}
 				evaluation={evaluation}
 				onSubmit={onSubmit}
-				setFinalValue={(value: Evaluation) =>
-					onChange({ valeur: value, unité })
-				}
+				setFinalValue={() => onChange({ valeur: value, unité })}
 			/>
 		)
 	}

--- a/source/components/conversation/RuleInput.tsx
+++ b/source/components/conversation/RuleInput.tsx
@@ -1,5 +1,11 @@
+import DateInput from '@/components/conversation/DateInput'
+import estimationQuestions from '@/components/conversation/estimationQuestions'
 import Input from '@/components/conversation/Input'
+import ParagrapheInput from '@/components/conversation/ParagrapheInput'
 import Question, { Choice } from '@/components/conversation/Question'
+import NumberedMosaic from '@/components/conversation/select/NumberedMosaic'
+import SelectDevices from '@/components/conversation/select/SelectDevices'
+import TextInput from '@/components/conversation/TextInput'
 import CurrencyInput from '@/components/CurrencyInput/CurrencyInput'
 import PercentageField from '@/components/PercentageField'
 import {
@@ -24,12 +30,6 @@ import Engine, {
 } from 'publicodes'
 import React, { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import DateInput from './DateInput'
-import estimationQuestions from './estimationQuestions'
-import ParagrapheInput from './ParagrapheInput'
-import NumberedMosaic from './select/NumberedMosaic'
-import SelectDevices from './select/SelectDevices'
-import TextInput from './TextInput'
 
 export type Value = any
 
@@ -87,7 +87,9 @@ export default function RuleInput({
 	noSuggestions = false,
 }: RuleInputProps) {
 	const { t } = useTranslation()
-	const engine = givenEngine ?? useContext(EngineContext) //related to Survey Context : we enable the engine to be different according to the simulation rules we are working with.
+	// Related to Survey Context : we enable the engine to be different according to
+	// the simulation rules we are working with.
+	const engine = givenEngine ?? useContext(EngineContext)
 	const rule = engine.getRule(dottedName)
 	const evaluation = engine.evaluate(dottedName)
 	const rules = engine.getParsedRules() as NGCRulesNodes
@@ -142,8 +144,6 @@ export default function RuleInput({
 
 		switch (mosaicParams['type']) {
 			case 'selection': {
-				console.log('DEBUG === mosaicParams', mosaicParams)
-				debugger
 				return (
 					<SelectDevices
 						{...{

--- a/source/components/conversation/SimulationEnding.tsx
+++ b/source/components/conversation/SimulationEnding.tsx
@@ -1,25 +1,27 @@
 import { Trans } from 'react-i18next'
 
-export default ({ customEnd, customEndMessages }) => (
-	<div style={{ textAlign: 'center' }} data-cypress-id="simulation-ending">
-		{customEnd ?? (
-			<>
-				<h3>
-					<Trans i18nKey="simulation-end.title">
-						🌟 Vous avez complété cette simulation
-					</Trans>
-				</h3>
-				<p>
-					{customEndMessages ? (
-						customEndMessages
-					) : (
-						<Trans i18nKey="simulation-end.text">
-							Vous avez maintenant accès à l'estimation la plus précise
-							possible.
+export default ({ customEnd, customEndMessages }) => {
+	return (
+		<div style={{ textAlign: 'center' }} data-cypress-id="simulation-ending">
+			{customEnd ?? (
+				<>
+					<h3>
+						<Trans i18nKey="simulation-end.title">
+							🌟 Vous avez complété cette simulation
 						</Trans>
-					)}
-				</p>
-			</>
-		)}
-	</div>
-)
+					</h3>
+					<p>
+						{customEndMessages ? (
+							customEndMessages
+						) : (
+							<Trans i18nKey="simulation-end.text">
+								Vous avez maintenant accès à l'estimation la plus précise
+								possible.
+							</Trans>
+						)}
+					</p>
+				</>
+			)}
+		</div>
+	)
+}

--- a/source/components/conversation/conversationUtils.ts
+++ b/source/components/conversation/conversationUtils.ts
@@ -4,10 +4,6 @@ import {
 	encodeRuleNameToSearchParam,
 } from '@/components/publicodesUtils'
 import { sortBy } from '@/utils'
-import { Dispatch } from 'react'
-import { NavigateFunction } from 'react-router'
-import { AnyAction } from 'redux'
-import { goToQuestion } from '../../actions/actions'
 import { getFocusedCategoryURLSearchParams } from '../../sites/publicodes/utils'
 
 export function sortQuestionsByCategory(
@@ -60,32 +56,30 @@ export function getPreviousQuestion(
 	return previousAnswers[currentQuestionIndex - 1]
 }
 
-export function goToQuestionOrNavigate({
-	question,
-	simulateurRootURL,
+export function updateCurrentURL({
+	paramName,
+	paramValue,
+	simulateurRootRuleURL,
 	focusedCategory,
-	toUse,
 }: {
-	question: DottedName | undefined
-	simulateurRootURL: string
+	paramName: string
+	paramValue?: string | undefined
+	simulateurRootRuleURL: string
 	focusedCategory: string | null
-	toUse: { dispatch: Dispatch<AnyAction> } | { navigate: NavigateFunction }
 }): void {
-	if (toUse['navigate'] != undefined) {
-		let searchParams = getFocusedCategoryURLSearchParams(focusedCategory)
-		if (question !== undefined) {
-			searchParams.append(
-				'question',
-				encodeRuleNameToSearchParam(question) ?? ''
-			)
-		}
-
-		toUse['navigate'](`/simulateur/${simulateurRootURL}?${searchParams}`, {
-			replace: true,
-		})
-	} else {
-		toUse['dispatch'](goToQuestion(question))
+	let searchParams = getFocusedCategoryURLSearchParams(focusedCategory)
+	if (paramValue != undefined) {
+		searchParams.append(
+			paramName,
+			encodeRuleNameToSearchParam(paramValue) ?? ''
+		)
 	}
+
+	window.history.replaceState(
+		{},
+		'',
+		`/simulateur/${simulateurRootRuleURL}?${searchParams}`
+	)
 }
 
 export function focusByCategory(

--- a/source/components/conversation/conversationUtils.ts
+++ b/source/components/conversation/conversationUtils.ts
@@ -2,8 +2,11 @@ import {
 	Category,
 	DottedName,
 	encodeRuleNameToSearchParam,
+	isValidQuestion,
+	NGCRulesNodes,
 } from '@/components/publicodesUtils'
 import { sortBy } from '@/utils'
+import { utils } from 'publicodes'
 import { getFocusedCategoryURLSearchParams } from '../../sites/publicodes/utils'
 
 export function sortQuestionsByCategory(
@@ -54,6 +57,22 @@ export function getPreviousQuestion(
 	// We'll explore the previous answers starting from the end,
 	// to find the first question that is not in the current mosaic
 	return previousAnswers[currentQuestionIndex - 1]
+}
+
+export function getMosaicParentRuleName(
+	rules: NGCRulesNodes,
+	ruleName: DottedName
+): DottedName {
+	let parentRuleName = ruleName
+
+	console.log('getMosaicParent > ', ruleName)
+
+	do {
+		parentRuleName = utils.ruleParent(parentRuleName)
+		console.log('parentRuleName', parentRuleName)
+	} while (parentRuleName != '' && !isValidQuestion(parentRuleName, rules))
+
+	return parentRuleName
 }
 
 export function updateCurrentURL({

--- a/source/components/conversation/conversationUtils.ts
+++ b/source/components/conversation/conversationUtils.ts
@@ -5,15 +5,15 @@ import {
 	isValidQuestion,
 	NGCRulesNodes,
 } from '@/components/publicodesUtils'
+import { getFocusedCategoryURLSearchParams } from '@/sites/publicodes/utils'
 import { sortBy } from '@/utils'
 import { utils } from 'publicodes'
-import { getFocusedCategoryURLSearchParams } from '../../sites/publicodes/utils'
 
 export function sortQuestionsByCategory(
 	nextQuestions: DottedName[],
 	orderByCategories: Category[]
 ): DottedName[] {
-	let sort = sortBy((question: string | string[]) => {
+	const sort = sortBy((question: string | string[]) => {
 		const category = orderByCategories.find(
 			(c) => question.indexOf(c.dottedName) === 0
 		)
@@ -65,11 +65,8 @@ export function getMosaicParentRuleName(
 ): DottedName {
 	let parentRuleName = ruleName
 
-	console.log('getMosaicParent > ', ruleName)
-
 	do {
 		parentRuleName = utils.ruleParent(parentRuleName)
-		console.log('parentRuleName', parentRuleName)
 	} while (parentRuleName != '' && !isValidQuestion(parentRuleName, rules))
 
 	return parentRuleName
@@ -86,7 +83,7 @@ export function updateCurrentURL({
 	simulateurRootRuleURL: string
 	focusedCategory: string | null
 }): void {
-	let searchParams = getFocusedCategoryURLSearchParams(focusedCategory)
+	const searchParams = getFocusedCategoryURLSearchParams(focusedCategory)
 	if (paramValue != undefined) {
 		searchParams.append(
 			paramName,
@@ -108,7 +105,7 @@ export function focusByCategory(
 	if (!focusedCategory) {
 		return questions
 	}
-	const filtered = questions.filter((q) => q.indexOf(focusedCategory) === 0)
+	const filtered = questions.filter((q) => q.startsWith(focusedCategory))
 	//this is important : if all questions of a focus have been answered
 	// then don't triggered the end screen, just ask the other questions
 	// as if no focus

--- a/source/components/conversation/select/SelectDevices.tsx
+++ b/source/components/conversation/select/SelectDevices.tsx
@@ -1,3 +1,4 @@
+import { updateSituation } from '@/actions/actions'
 import MosaicInputSuggestions from '@/components/conversation/MosaicInputSuggestions'
 import MosaicStamp from '@/components/conversation/select/MosaicStamp'
 import { Mosaic, MosaicItemLabel } from '@/components/conversation/select/UI'
@@ -5,7 +6,6 @@ import Checkbox from '@/components/ui/Checkbox'
 import { situationSelector } from '@/selectors/simulationSelectors'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { updateSituation } from '../../../actions/actions'
 
 export default function SelectDevices({
 	dottedName,

--- a/source/components/conversation/select/SelectDevices.tsx
+++ b/source/components/conversation/select/SelectDevices.tsx
@@ -1,16 +1,11 @@
-import { updateSituation } from 'Actions/actions'
-import Checkbox from 'Components/ui/Checkbox'
+import MosaicInputSuggestions from '@/components/conversation/MosaicInputSuggestions'
+import MosaicStamp from '@/components/conversation/select/MosaicStamp'
+import { Mosaic, MosaicItemLabel } from '@/components/conversation/select/UI'
+import Checkbox from '@/components/ui/Checkbox'
+import { situationSelector } from '@/selectors/simulationSelectors'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { situationSelector } from 'Selectors/simulationSelectors'
-import styled from 'styled-components'
-import MosaicInputSuggestions from '../MosaicInputSuggestions'
-import MosaicStamp from './MosaicStamp'
-import { Mosaic, MosaicItemLabel, mosaicLabelStyle } from './UI'
-
-const MosaicLabelDiv = styled.div`
-	${mosaicLabelStyle}
-`
+import { updateSituation } from '../../../actions/actions'
 
 export default function SelectDevices({
 	dottedName,
@@ -25,8 +20,11 @@ export default function SelectDevices({
 		[]
 	)
 
-	// for now, if nothing is checked, after having check something, 'suivant' button will have same effect as 'je ne sais pas'
-	// we can imagine a useeffect that set to 0 situation of dottedname every time all card are unchecked (after user checked something at least once)
+	// for now, if nothing is checked, after having check something,
+	// 'suivant' button will have same effect as 'je ne sais pas'
+	// we can imagine a useeffect that set to 0 situation
+	// of dottedname every time all card are unchecked
+	// (after user checked something at least once)
 
 	return (
 		<div>
@@ -42,18 +40,19 @@ export default function SelectDevices({
 						{
 							dottedName: name,
 							title,
-							rawNode: { description, icônes },
+							rawNode: { icônes },
 						},
 						question,
 					]) => {
-						const situationValue = situation[question.dottedName],
-							value =
-								situationValue != null
-									? situationValue
-									: // unlike the NumberedMosaic, we don't preselect cards choices here
-									  // user tests showed us it is now well received
-									  'non',
-							isNotActive = 'inactif' in question.rawNode
+						const situationValue = situation[question.dottedName]
+						const value =
+							situationValue != null
+								? situationValue
+								: // unlike the NumberedMosaic, we don't preselect cards choices here
+								  // user tests showed us it is now well received
+								  'non'
+						const isNotActive = 'inactif' in question.rawNode
+
 						return (
 							<li
 								className={
@@ -88,7 +87,7 @@ export default function SelectDevices({
 												dispatch(
 													updateSituation(
 														question.dottedName,
-														value == 'oui' ? 'non' : 'oui'
+														value === 'oui' ? 'non' : 'oui'
 													)
 												)
 											}

--- a/source/components/publicodesUtils.tsx
+++ b/source/components/publicodesUtils.tsx
@@ -430,7 +430,7 @@ export function decodeRuleNameFromSearchParam(encodedName: string): DottedName {
 	return coreUtils.decodeRuleName(encodedName.replaceAll('.', '/'))
 }
 
-export function isValidRule(ruleName: DottedName, rules: NGCRulesNodes) {
+export function isValidQuestion(ruleName: DottedName, rules: NGCRulesNodes) {
 	if (rules == undefined) {
 		return false
 	}

--- a/source/components/utils/EngineContext.tsx
+++ b/source/components/utils/EngineContext.tsx
@@ -3,7 +3,7 @@ import { intersect, pick } from '@/utils'
 import Engine from 'publicodes'
 import React, { createContext, useContext } from 'react'
 
-export const EngineContext = createContext<Engine | undefined>(new Engine({}))
+export const EngineContext = createContext<Engine>(new Engine({}))
 export const EngineProvider = EngineContext.Provider
 
 export const engineOptions = {

--- a/source/hooks/useNextQuestion.tsx
+++ b/source/hooks/useNextQuestion.tsx
@@ -101,6 +101,7 @@ export function getNextQuestions(
 		const rule = engine?.getRule(name)
 		return rule.rawNode.question != null
 	})
+
 	const lastStep = last(answeredQuestions)
 	// L'ajout de la réponse permet de traiter les questions dont la réponse est
 	// "une possibilité", exemple "contrat salarié . cdd"
@@ -150,6 +151,8 @@ export const useNextQuestions = function (): Array<DottedName> {
 			: []
 	}, [missingVariables, questionsConfig, answeredQuestions, situation, engine])
 
+	console.log('nextQuestions', nextQuestions)
+	console.log('currentQuestion', currentQuestion)
 	if (currentQuestion && currentQuestion !== nextQuestions[0]) {
 		return [currentQuestion, ...nextQuestions]
 	}

--- a/source/hooks/useNextQuestion.tsx
+++ b/source/hooks/useNextQuestion.tsx
@@ -151,8 +151,6 @@ export const useNextQuestions = function (): Array<DottedName> {
 			: []
 	}, [missingVariables, questionsConfig, answeredQuestions, situation, engine])
 
-	console.log('nextQuestions', nextQuestions)
-	console.log('currentQuestion', currentQuestion)
 	if (currentQuestion && currentQuestion !== nextQuestions[0]) {
 		return [currentQuestion, ...nextQuestions]
 	}

--- a/source/reducers/rootReducer.ts
+++ b/source/reducers/rootReducer.ts
@@ -281,20 +281,16 @@ function conference(state = null, { type, room, ydoc, provider }) {
 export type TutorialStateStatus = 'skip' | 'done' | undefined
 export type TutorialState = {
 	[id: string]: TutorialStateStatus
-	/** fromRule is used to know if the tutorial was triggered by a specific rule
-	 (appart from 'bilan') and if so, to know if it was skipped or not.*/
-	fromRule?: TutorialStateStatus
 }
 
 // Tutorials are the main tutorial for the /simulateur/bilan simulation,
 // but also the small category pages displayed before starting the category,
 // as a pause for the user
-function tutorials(state: TutorialState = {}, { type, id, unskip, fromRule }) {
+function tutorials(state: TutorialState = {}, { type, id, unskip }) {
 	if (type === 'SKIP_TUTORIAL') {
 		return {
 			...state,
 			[id]: unskip ? undefined : 'skip',
-			fromRule: !fromRule ? state.fromRule : fromRule,
 		}
 	} else if (type === 'RESET_INTRO_TUTORIAL') {
 		return Object.fromEntries(

--- a/source/reducers/rootReducer.ts
+++ b/source/reducers/rootReducer.ts
@@ -142,7 +142,6 @@ function simulation(
 			}
 		}
 		case 'UPDATE_SITUATION': {
-			console.log('UPDATE_SITUATION', action)
 			const targets = objectifsSelector({ simulation: state } as AppState)
 			const situation = state.situation
 			const { fieldName: dottedName, value } = action
@@ -155,8 +154,6 @@ function simulation(
 								: situation),
 							[dottedName]: value,
 					  }
-
-			console.log('newSituation', newSituation)
 
 			return {
 				...state,

--- a/source/reducers/rootReducer.ts
+++ b/source/reducers/rootReducer.ts
@@ -142,20 +142,25 @@ function simulation(
 			}
 		}
 		case 'UPDATE_SITUATION': {
+			console.log('UPDATE_SITUATION', action)
 			const targets = objectifsSelector({ simulation: state } as AppState)
 			const situation = state.situation
 			const { fieldName: dottedName, value } = action
+			const newSituation =
+				value === undefined
+					? omit([dottedName], situation)
+					: {
+							...(targets.includes(dottedName)
+								? omit(targets, situation)
+								: situation),
+							[dottedName]: value,
+					  }
+
+			console.log('newSituation', newSituation)
+
 			return {
 				...state,
-				situation:
-					value === undefined
-						? omit([dottedName], situation)
-						: {
-								...(targets.includes(dottedName)
-									? omit(targets, situation)
-									: situation),
-								[dottedName]: value,
-						  },
+				situation: newSituation,
 			}
 		}
 		case 'STEP_ACTION': {

--- a/source/selectors/simulationSelectors.ts
+++ b/source/selectors/simulationSelectors.ts
@@ -58,8 +58,7 @@ export const useTestCompleted = () => {
 	const nextQuestions = useNextQuestions()
 	const objectives = useSelector(objectifsSelector)
 
-	const testCompleted = objectives.length > 0 && nextQuestions.length === 0
-	return testCompleted
+	return objectives.length > 0 && nextQuestions.length === 0
 }
 
 // Designed to store simulation data in a DB, for the purpose of the survey

--- a/source/selectors/simulationSelectors.ts
+++ b/source/selectors/simulationSelectors.ts
@@ -55,8 +55,8 @@ export const answeredQuestionsSelector = (state: AppState) =>
 	state.simulation?.foldedSteps ?? []
 
 export const useTestCompleted = () => {
-	const nextQuestions = useNextQuestions(),
-		objectives = useSelector(objectifsSelector)
+	const nextQuestions = useNextQuestions()
+	const objectives = useSelector(objectifsSelector)
 
 	const testCompleted = objectives.length > 0 && nextQuestions.length === 0
 	return testCompleted

--- a/source/sites/publicodes/ActionConversation.tsx
+++ b/source/sites/publicodes/ActionConversation.tsx
@@ -2,9 +2,9 @@ import { setSimulationConfig } from '@/actions/actions'
 import Simulation from '@/components/Simulation'
 import { useNextQuestions } from '@/hooks/useNextQuestion'
 import { AppState } from '@/reducers/rootReducer'
+import { questionConfig } from '@/sites/publicodes/questionConfig'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { questionConfig } from './questionConfig'
 
 export default ({ dottedName }) => {
 	const nextQuestions = useNextQuestions()
@@ -15,7 +15,7 @@ export default ({ dottedName }) => {
 	// to be continued...
 	const config = {
 		objectifs: [dottedName],
-		situation: { ...(configSet?.situation || {}) },
+		situation: { ...(configSet?.situation ?? {}) },
 		questions: questionConfig,
 	}
 
@@ -35,6 +35,7 @@ export default ({ dottedName }) => {
 			conversationProps={{
 				customEnd: <div />,
 				questionHeadingLevel: 3,
+				isFromActionCard: true,
 			}}
 		/>
 	) : null

--- a/source/sites/publicodes/ActionConversation.tsx
+++ b/source/sites/publicodes/ActionConversation.tsx
@@ -35,7 +35,6 @@ export default ({ dottedName }) => {
 			conversationProps={{
 				customEnd: <div />,
 				questionHeadingLevel: 3,
-				isFromActionCard: true,
 			}}
 		/>
 	) : null

--- a/source/sites/publicodes/ActionPlus.js
+++ b/source/sites/publicodes/ActionPlus.js
@@ -1,13 +1,13 @@
-import { getTitle } from 'Components/publicodesUtils'
-import { Markdown } from 'Components/utils/markdown'
-import Meta from 'Components/utils/Meta'
-import { ScrollToTop } from 'Components/utils/Scroll'
+import { getTitle } from '@/components/publicodesUtils'
+import useFetchDocumentation from '@/components/useFetchDocumentation'
+import { Markdown } from '@/components/utils/markdown'
+import Meta from '@/components/utils/Meta'
+import { ScrollToTop } from '@/components/utils/Scroll'
 import { utils } from 'publicodes'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router'
 import { Link } from 'react-router-dom'
-import useFetchDocumentation from '../../components/useFetchDocumentation'
 
 export default () => {
 	const { t } = useTranslation()
@@ -15,7 +15,9 @@ export default () => {
 	const dottedName = utils.decodeRuleName(encodedName)
 	const rules = useSelector((state) => state.rules)
 	const documentation = useFetchDocumentation()
-	if (!documentation) return null
+	if (!documentation) {
+		return null
+	}
 
 	const rule = {
 		...rules[dottedName],

--- a/source/sites/publicodes/BandeauContribuer.js
+++ b/source/sites/publicodes/BandeauContribuer.js
@@ -1,9 +1,9 @@
-import animate from 'Components/ui/animate'
+import animate from '@/components/ui/animate'
+import { answeredQuestionsSelector } from '@/selectors/simulationSelectors'
 import { useEffect, useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
-import { answeredQuestionsSelector } from '../../selectors/simulationSelectors'
 
 export default () => {
 	const answers = useSelector(answeredQuestionsSelector),

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -53,19 +53,32 @@ const Simulateur = () => {
 	const rules = useSelector((state: AppState) => state.rules)
 	const ruleNames: DottedName[] = Object.keys(rules)
 
-	if (!simulatorRootNameURL || !ruleNames.includes(simulatorRootNameURL)) {
+	if (simulatorRootNameURL === undefined) {
+		return (
+			<Navigate to={`/simulateur/${MODEL_ROOT_RULE_NAME}`} replace={true} />
+		)
+	}
+
+	const simulatorRootRuleName = utils.decodeRuleName(simulatorRootNameURL)
+
+	if (!ruleNames.includes(simulatorRootRuleName)) {
 		console.log(
-			`Unknown rule ${simulatorRootNameURL}, redirecting to /simulateur/${MODEL_ROOT_RULE_NAME}...`
+			`Unknown rule ${simulatorRootRuleName}, redirecting to /simulateur/${MODEL_ROOT_RULE_NAME}...`
 		)
 		return (
 			<Navigate to={`/simulateur/${MODEL_ROOT_RULE_NAME}`} replace={true} />
 		)
 	}
 
-	return <SimulateurCore simulatorRootNameURL={simulatorRootNameURL} />
+	return (
+		<SimulateurCore
+			simulatorRootNameURL={simulatorRootNameURL}
+			simulatorRootRuleName={simulatorRootRuleName}
+		/>
+	)
 }
 
-const SimulateurCore = ({ simulatorRootNameURL }) => {
+const SimulateurCore = ({ simulatorRootNameURL, simulatorRootRuleName }) => {
 	const navigate = useNavigate()
 	const dispatch = useDispatch()
 	const { t } = useTranslation()
@@ -78,7 +91,6 @@ const SimulateurCore = ({ simulatorRootNameURL }) => {
 	// model root rule.
 	const isMainSimulation = isRootRule(simulatorRootNameURL)
 	const selectedRuleNameURLPath = searchParams.get('question') ?? ''
-	const simulatorRootRuleName = utils.decodeRuleName(simulatorRootNameURL)
 
 	const parsedRules = engine.getParsedRules() as NGCRulesNodes
 

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -22,6 +22,13 @@ import {
 	AppState,
 	objectifsConfigToDottedNameArray,
 } from '@/reducers/rootReducer'
+import { useTestCompleted } from '@/selectors/simulationSelectors'
+import BandeauContribuer from '@/sites/publicodes/BandeauContribuer'
+import InlineCategoryChart from '@/sites/publicodes/chart/InlineCategoryChart'
+import { enquêteSelector } from '@/sites/publicodes/enquête/enquêteSelector'
+import { questionConfig } from '@/sites/publicodes/questionConfig'
+import ScoreBar from '@/sites/publicodes/ScoreBar'
+import { getQuestionURLSearchParams } from '@/sites/publicodes/utils'
 import { motion } from 'framer-motion'
 import { utils } from 'publicodes'
 import { useEffect } from 'react'
@@ -29,13 +36,6 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavigateFunction, useNavigate } from 'react-router'
 import { Link, useParams } from 'react-router-dom'
-import { useTestCompleted } from '../../selectors/simulationSelectors'
-import BandeauContribuer from './BandeauContribuer'
-import InlineCategoryChart from './chart/InlineCategoryChart'
-import { enquêteSelector } from './enquête/enquêteSelector'
-import { questionConfig } from './questionConfig'
-import ScoreBar from './ScoreBar'
-import { getQuestionURLSearchParams } from './utils'
 
 function isEquivalentTargetArrays<T>(array1: T[], array2: T[]): boolean {
 	return (
@@ -43,11 +43,6 @@ function isEquivalentTargetArrays<T>(array1: T[], array2: T[]): boolean {
 		array1.every((value, index) => value === array2[index])
 	)
 }
-
-/*
- * Here the URL specs:
- * TODO: document this
- */
 
 const Simulateur = () => {
 	const navigate = useNavigate()
@@ -83,10 +78,10 @@ const Simulateur = () => {
 	const noCongratsURL = searchParams.get('respiration') !== 'congrats'
 
 	const { selectedRuleDottedName, selectedRuleURL } =
-		// NOTE(@EmileRolley): we need to differenciate the question search params
+		// FIXME(@EmileRolley): we need to differenciate the question search params
 		// set in Conversation when the last question is answered from the one
 		// specified by the user in the URL to redirect only if the test is
-		// completed.
+		// completed. For now, the redirection is deactivated.
 		/* isTestCompleted && noCongratsURL */
 		false
 			? getValidSelectedRuleInfos(

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -62,15 +62,14 @@ const Simulateur = () => {
 		)
 	}
 
-	return <SimulateurCore />
+	return <SimulateurCore simulatorRootNameURL={simulatorRootNameURL} />
 }
 
-const SimulateurCore = () => {
+const SimulateurCore = ({ simulatorRootNameURL }) => {
 	const navigate = useNavigate()
 	const dispatch = useDispatch()
 	const { t } = useTranslation()
 	const searchParams = new URLSearchParams(window.location.search)
-	const simulatorRootNameURL = urlParams['*']
 	const isTestCompleted = useTestCompleted()
 	const rules = useSelector((state: AppState) => state.rules)
 	const engine = useEngine()
@@ -141,7 +140,8 @@ const SimulateurCore = () => {
 	const displayTutorial = isMainSimulation && !tutorials.testIntro
 
 	if (displayTutorial) {
-		return navigate(`/tutoriel`, { replace: true })
+		navigate(`/tutoriel`, { replace: true })
+		return null
 	}
 
 	return (
@@ -184,7 +184,7 @@ const SimulateurCore = () => {
 						customEnd: isMainSimulation ? (
 							<MainSimulationEnding {...{ rules, engine }} />
 						) : simulatorRule.description ? (
-							<Markdown children={simulatorRule.description} noRouter={false} />
+							<Markdown noRouter={false}>{simulatorRule.description}</Markdown>
 						) : (
 							<EndingCongratulations />
 						),
@@ -203,6 +203,10 @@ type SelectedRuleInfos = {
 }
 
 /**
+ * NOTE(@EmileRolley): this function is unsused for now, but could be used if we
+ * decide to redirect to specific question when the test is completed according
+ * to the 'question' search param. If not, we could remove it.
+ *
  * A rule is valid if it exists, is a question and is not a mosaic child.
  *
  * However, if the rule is a mosaic question the returned [selectedRuleDottedName] will

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -59,7 +59,7 @@ const Simulateur = () => {
 	const { t } = useTranslation()
 
 	if (!simulatorRootNameURL) {
-		navigate(`/simulateur/${MODEL_ROOT_RULE_NAME}`, { replace: true })
+		return navigate(`/simulateur/${MODEL_ROOT_RULE_NAME}`, { replace: true })
 	}
 
 	// The main simulation corresponds to the whole test, i.e selected rule is the
@@ -74,7 +74,7 @@ const Simulateur = () => {
 		console.log(
 			`Unknown rule ${simulatorRootNameURL}, redirecting to /simulateur/${MODEL_ROOT_RULE_NAME}...`
 		)
-		navigate(`/simulateur/${MODEL_ROOT_RULE_NAME}`, { replace: true })
+		return navigate(`/simulateur/${MODEL_ROOT_RULE_NAME}`, { replace: true })
 	}
 
 	const engine = useEngine()
@@ -130,7 +130,7 @@ const Simulateur = () => {
 	const displayTutorial = isMainSimulation && !tutorials.testIntro
 
 	if (displayTutorial) {
-		navigate(`/tutoriel`, { replace: true })
+		return navigate(`/tutoriel`, { replace: true })
 	}
 
 	return (
@@ -178,7 +178,7 @@ const Simulateur = () => {
 							<EndingCongratulations />
 						),
 					}}
-					explanations={<InlineCategoryChart givenEngine={undefined} />}
+					explanations={<InlineCategoryChart />}
 				/>
 			</div>
 			<BandeauContribuer />

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -8,7 +8,7 @@ import {
 	FullName,
 	getRelatedMosaicInfosIfExists,
 	isRootRule,
-	isValidRule,
+	isValidQuestion,
 	MODEL_ROOT_RULE_NAME,
 	NGCRulesNodes,
 } from '@/components/publicodesUtils'
@@ -36,6 +36,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavigateFunction, useNavigate } from 'react-router'
 import { Link, useParams } from 'react-router-dom'
+import { getMosaicParentRuleName } from '../../components/conversation/conversationUtils'
 
 function isEquivalentTargetArrays<T>(array1: T[], array2: T[]): boolean {
 	return (
@@ -209,14 +210,8 @@ function getValidSelectedRuleInfos(
 ): SelectedRuleInfos {
 	const searchParams = new URLSearchParams(window.location.search)
 
-	if (selectedRuleName != '' && !isValidRule(selectedRuleName, rules)) {
-		while (selectedRuleName != '' && !isValidRule(selectedRuleName, rules)) {
-			const parentRuleName = utils.ruleParent(selectedRuleName)
-			console.log(
-				`Unknown question ${selectedRuleName}, trying ${parentRuleName}...`
-			)
-			selectedRuleName = parentRuleName
-		}
+	if (selectedRuleName != '' && !isValidQuestion(selectedRuleName, rules)) {
+		selectedRuleName = getMosaicParentRuleName(rules, selectedRuleName)
 
 		if (selectedRuleName == '') {
 			console.log(

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -27,7 +27,7 @@ import { utils } from 'publicodes'
 import { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { Navigate, useNavigate } from 'react-router'
+import { NavigateFunction, useNavigate } from 'react-router'
 import { Link, useParams } from 'react-router-dom'
 import BandeauContribuer from './BandeauContribuer'
 import InlineCategoryChart from './chart/InlineCategoryChart'
@@ -57,7 +57,7 @@ const Simulateur = () => {
 	const { t } = useTranslation()
 
 	if (!simulatorRootNameURL) {
-		return <Navigate to={`/simulateur/${MODEL_ROOT_RULE_NAME}`} replace />
+		navigate(`/simulateur/${MODEL_ROOT_RULE_NAME}`, { replace: true })
 	}
 
 	// The main simulation corresponds to the whole test, i.e selected rule is the
@@ -72,7 +72,7 @@ const Simulateur = () => {
 		console.log(
 			`Unknown rule ${simulatorRootNameURL}, redirecting to /simulateur/${MODEL_ROOT_RULE_NAME}...`
 		)
-		return <Navigate to={`/simulateur/${MODEL_ROOT_RULE_NAME}`} replace />
+		navigate(`/simulateur/${MODEL_ROOT_RULE_NAME}`, { replace: true })
 	}
 
 	const engine = useEngine()
@@ -141,7 +141,7 @@ const Simulateur = () => {
 			})
 			return navigate(`/tutoriel?${searchParams}`, { replace: true })
 		}
-		return navigate(`/tutoriel`, { replace: true })
+		navigate(`/tutoriel`, { replace: true })
 	}
 
 	return (
@@ -212,9 +212,9 @@ type SelectedRuleInfos = {
 function getValidSelectedRuleInfos(
 	selectedRuleName: DottedName,
 	simulatorRootRuleNameURL: string,
-	rules: NGCRulesNodes
+	rules: NGCRulesNodes,
+	navigate: NavigateFunction
 ): SelectedRuleInfos {
-	const navigate = useNavigate()
 	const searchParams = new URLSearchParams(window.location.search)
 
 	if (selectedRuleName != '' && !isValidRule(selectedRuleName, rules)) {

--- a/source/sites/publicodes/Simulateur.tsx
+++ b/source/sites/publicodes/Simulateur.tsx
@@ -80,14 +80,22 @@ const Simulateur = () => {
 	const engine = useEngine()
 	const parsedRules = engine.getParsedRules() as NGCRulesNodes
 
-	const { selectedRuleDottedName, selectedRuleURL } = isTestCompleted
-		? getValidSelectedRuleInfos(
-				decodeRuleNameFromSearchParam(selectedRuleNameURLPath),
-				simulatorRootNameURL,
-				parsedRules,
-				navigate
-		  )
-		: { selectedRuleDottedName: undefined, selectedRuleURL: undefined }
+	const noCongratsURL = searchParams.get('respiration') !== 'congrats'
+
+	const { selectedRuleDottedName, selectedRuleURL } =
+		// NOTE(@EmileRolley): we need to differenciate the question search params
+		// set in Conversation when the last question is answered from the one
+		// specified by the user in the URL to redirect only if the test is
+		// completed.
+		/* isTestCompleted && noCongratsURL */
+		false
+			? getValidSelectedRuleInfos(
+					decodeRuleNameFromSearchParam(selectedRuleNameURLPath),
+					simulatorRootNameURL,
+					parsedRules,
+					navigate
+			  )
+			: { selectedRuleDottedName: undefined, selectedRuleURL: undefined }
 
 	const simulatorRule = rules[simulatorRootRuleName]
 	const evaluation = engine.evaluate(simulatorRootRuleName)

--- a/source/sites/publicodes/chart/InlineCategoryChart.tsx
+++ b/source/sites/publicodes/chart/InlineCategoryChart.tsx
@@ -7,22 +7,22 @@ import {
 	currentQuestionSelector,
 	situationSelector,
 } from '@/selectors/simulationSelectors'
+import CategoryVisualisation from '@/sites/publicodes/CategoryVisualisation'
+import DetailedBarChartIcon from '@/sites/publicodes/chart/DetailedBarChartIcon'
+import Chart from '@/sites/publicodes/chart/index.js'
+import { activatedSpecializedVisualisations } from '@/sites/publicodes/chart/SpecializedVisualisation'
+import SubCategoriesChart from '@/sites/publicodes/chart/SubCategoriesChart'
+import useContinuousCategory from '@/sites/publicodes/chart/useContinuousCategory'
 import { useQuery } from '@/utils'
 import Engine from 'publicodes'
 import React, { Suspense, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import CategoryVisualisation from '../CategoryVisualisation'
-import DetailedBarChartIcon from './DetailedBarChartIcon'
-import Chart from './index.js'
-import { activatedSpecializedVisualisations } from './SpecializedVisualisation'
-import SubCategoriesChart from './SubCategoriesChart'
-import useContinuousCategory from './useContinuousCategory'
 
 const SpecializedVisualisation = React.lazy(
 	() =>
 		import(
-			/* webpackChunkName: 'SpecializedVisualisation' */ './SpecializedVisualisation'
+			/* webpackChunkName: 'SpecializedVisualisation' */ '@/sites/publicodes/chart/SpecializedVisualisation'
 		)
 )
 
@@ -47,7 +47,7 @@ export default ({ givenEngine }: { givenEngine?: Engine }) => {
 
 	useEffect(() => {
 		setCategories(mapAbreviation(rules, engine))
-	}, [rules, situation])
+	}, [rules, engine, situation])
 
 	const displayedCategory = useContinuousCategory(categories)
 

--- a/source/sites/publicodes/chart/InlineCategoryChart.tsx
+++ b/source/sites/publicodes/chart/InlineCategoryChart.tsx
@@ -35,13 +35,15 @@ function mapAbreviation(rules: any, engine: Engine) {
 	})
 }
 
-export default ({ givenEngine }) => {
+export default ({ givenEngine }: { givenEngine?: Engine }) => {
 	const { t } = useTranslation()
 	const situation = useSelector(situationSelector) // needed for this component to refresh on situation change :
 	const rules = useSelector((state: AppState) => state.rules)
 	const engine = givenEngine ?? useEngine()
 	const [categories, setCategories] = useState(mapAbreviation(rules, engine))
 	const tutorials = useSelector((state: AppState) => state.tutorials)
+
+	const [traditionalChartShown, showTraditionalChart] = useState(false)
 
 	useEffect(() => {
 		setCategories(mapAbreviation(rules, engine))
@@ -52,7 +54,9 @@ export default ({ givenEngine }) => {
 	const currentQuestion = useSelector(currentQuestionSelector)
 	const focusedCategory = useQuery().get('catégorie')
 
-	if (!categories) return null
+	if (!categories) {
+		return null
+	}
 
 	const inRespiration =
 		displayedCategory &&
@@ -61,7 +65,6 @@ export default ({ givenEngine }) => {
 	const categoryColor = displayedCategory && displayedCategory.color
 
 	const value = currentQuestion && engine.evaluate(currentQuestion).nodeValue
-	const [traditionalChartShown, showTraditionalChart] = useState(false)
 
 	const showSecondLevelChart =
 		!inRespiration &&
@@ -71,7 +74,7 @@ export default ({ givenEngine }) => {
 	const specializedVisualisationShown =
 		activatedSpecializedVisualisations.includes(currentQuestion)
 
-	if (!inRespiration && specializedVisualisationShown)
+	if (!inRespiration && specializedVisualisationShown) {
 		return (
 			<div
 				css={`
@@ -90,6 +93,7 @@ export default ({ givenEngine }) => {
 				</Suspense>
 			</div>
 		)
+	}
 
 	return (
 		<div

--- a/source/sites/publicodes/chart/SpecializedVisualisation.tsx
+++ b/source/sites/publicodes/chart/SpecializedVisualisation.tsx
@@ -1,11 +1,12 @@
+import RavijenChart from '@/sites/publicodes/chart/RavijenChart'
 import { motion } from 'framer-motion'
-import RavijenChart from './RavijenChart'
 
 export const activatedSpecializedVisualisations = [
 	'services sociétaux . question rhétorique',
 ]
+
 export default ({ currentQuestion, categoryColor, value }) => {
-	if (currentQuestion === 'services sociétaux . question rhétorique')
+	if (currentQuestion === 'services sociétaux . question rhétorique') {
 		return (
 			<motion.div
 				initial={{ scale: 0 }}
@@ -27,6 +28,7 @@ export default ({ currentQuestion, categoryColor, value }) => {
 				/>
 			</motion.div>
 		)
+	}
 
 	// Not ready yet. Animation should start from the bottom
 	// Should be iterated

--- a/source/sites/publicodes/tutorial/Tutorial.tsx
+++ b/source/sites/publicodes/tutorial/Tutorial.tsx
@@ -9,7 +9,7 @@ import { AppState } from '@/reducers/rootReducer'
 import { enquêteSelector } from 'Enquête/enquêteSelector'
 import { useContext, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Navigate, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { generateImageLink } from '../fin'
 import HorizontalSwipe from '../HorizontalSwipe'
 import Categories from './Categories'
@@ -22,21 +22,8 @@ import WarmingMeasure from './WarmingMeasure'
 export default ({}) => {
 	const navigate = useNavigate()
 	const dispatch = useDispatch()
-	const urlParams = new URLSearchParams(window.location.search)
 
-	const fromRuleURLParam = urlParams.get('fromRuleURL')
-
-	const targetUrl = fromRuleURLParam
-		? fromRuleURLParam
-		: `/simulateur/${MODEL_ROOT_RULE_NAME}`
-
-	if (fromRuleURLParam) {
-		// The tutorial is skipped when redirected from a specific rule URL
-		// (e.g. /simulateur/bilan/logement/chauffage)
-		// [tutorials.fromRule = 'skip']
-		dispatch(skipTutorial('testIntro', false, 'skip'))
-		return <Navigate to={targetUrl} replace />
-	}
+	const targetUrl = `/simulateur/${MODEL_ROOT_RULE_NAME}`
 
 	const tutorials = useSelector((state: AppState) => state.tutorials)
 	const tutos = Object.entries(tutorials)
@@ -50,17 +37,7 @@ export default ({}) => {
 	const { trackEvent } = useContext(MatomoContext)
 
 	const skip = (name: string, unskip = false) =>
-		dispatch(
-			skipTutorial(
-				name,
-				unskip,
-				tutorials.fromRule == 'skip'
-					? // Returning to 'simulateur/bilan' after skipping the tutorial from a
-					  // specific rule URL
-					  'done'
-					: tutorials.fromRule
-			)
-		)
+		dispatch(skipTutorial(name, unskip))
 
 	const last = index === slides.length - 1
 	const next = () => {

--- a/source/sites/publicodes/tutorial/Tutorial.tsx
+++ b/source/sites/publicodes/tutorial/Tutorial.tsx
@@ -6,20 +6,20 @@ import Meta from '@/components/utils/Meta'
 import { MatomoContext } from '@/contexts/MatomoContext'
 import useKeypress from '@/hooks/useKeyPress'
 import { AppState } from '@/reducers/rootReducer'
-import { enquêteSelector } from 'Enquête/enquêteSelector'
-import { useContext, useEffect } from 'react'
+import { enquêteSelector } from '@/sites/publicodes/enquête/enquêteSelector'
+import { generateImageLink } from '@/sites/publicodes/fin'
+import HorizontalSwipe from '@/sites/publicodes/HorizontalSwipe'
+import Categories from '@/sites/publicodes/tutorial/Categories'
+import ClimateWarming from '@/sites/publicodes/tutorial/ClimateWarming'
+import Instructions from '@/sites/publicodes/tutorial/Instructions'
+import Target from '@/sites/publicodes/tutorial/Target'
+import Slide from '@/sites/publicodes/tutorial/TutorialSlide'
+import WarmingMeasure from '@/sites/publicodes/tutorial/WarmingMeasure'
+import { useCallback, useContext, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
-import { generateImageLink } from '../fin'
-import HorizontalSwipe from '../HorizontalSwipe'
-import Categories from './Categories'
-import ClimateWarming from './ClimateWarming'
-import Instructions from './Instructions'
-import Target from './Target'
-import Slide from './TutorialSlide'
-import WarmingMeasure from './WarmingMeasure'
 
-export default ({}) => {
+export default () => {
 	const navigate = useNavigate()
 	const dispatch = useDispatch()
 
@@ -36,8 +36,10 @@ export default ({}) => {
 
 	const { trackEvent } = useContext(MatomoContext)
 
-	const skip = (name: string, unskip = false) =>
-		dispatch(skipTutorial(name, unskip))
+	const skip = useCallback(
+		(name: string, unskip = false) => dispatch(skipTutorial(name, unskip)),
+		[dispatch]
+	)
 
 	const last = index === slides.length - 1
 	const next = () => {
@@ -59,7 +61,7 @@ export default ({}) => {
 		if (Object.keys(tutorials).includes('testIntro5')) {
 			skip('testIntro')
 		}
-	}, [tutorials])
+	}, [tutorials, skip])
 
 	// This results from a bug that introduced "slide5" in users' cache :/
 	// Here we avoid an error

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -119,8 +119,11 @@ export function range(start: number, end: number) {
 }
 
 export function omit(keys, obj) {
-	if (!keys.length) return obj
+	if (!keys.length) {
+		return obj
+	}
 	const { [keys.pop()]: omitted, ...rest } = obj
+
 	return omit(keys, rest)
 }
 


### PR DESCRIPTION
Closes #1159 by removing the previous logic added to skip the tutorial and to go to a specific question when coming from an URL with a specific `question` search param.

~~Now, if the test isn't completed, whatever URL is used, the last unanswered question will be displayed. However, if the user answered all questions, it will display the question corresponding to the rule name specified in the `question` parameter.~~
**EDIT: this PR suspend the feature to go to a specific question even if the test is completed. Indeed, this isn't trivial to differentiate the last question answered from a specific question redirection with the `question` search param.**

Adds a new `thématique` search param for each category _respirations_ (e.g. `thématique=transport`) instead of using the first question of the category, this leads to cleaner stats.

## Changelog

* removes the `formRule` attributes used in the action to skip the tutorial
* removes a `useNavigate` call inside a non-component function which was causing trouble
* updates Cypress end-to-end tests accordingly to the new wanted behavior
* add a _proxy_ to the `Simulateur` component to redirect in order to avoid conditional call of react hook
* basic refactoring (imports unified with `@/` + correct some linting errors) in touched files
* fixes some basic eslint errors in touched files