### PR TITLE
A/B/n Testing via Netlify split testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,20 @@
 			}
 		</style>
 		<meta name="theme-color" content="#5758BB" />
+
+		<script type="text/javascript">
+			/* 
+				Manually setting Netlify code spliting cookie in iframe with sameSite=None and secure. 
+				See : https://answers.netlify.com/t/running-split-tests-in-an-iframe-adjust-nf-ab-cookie-settings/28754
+			*/
+			if (window.location.href.includes('iframe')) {
+				let cookieIsSet = document.cookie.includes('nf_ab')
+				if (!cookieIsSet) {
+					document.cookie = `nf_ab=${Math.random()}; sameSite=None; secure=true`
+					window.location.reload(true) // We need to reload the page for the client to match the server
+				}
+			}
+		</script>
 	</head>
 
 	<body>

--- a/source/analytics/matomo-events.ts
+++ b/source/analytics/matomo-events.ts
@@ -76,6 +76,14 @@ export const getMatomoEventChangeRegion = (code: string) => [
 	code,
 ]
 
+// Current Branch
+export const getMatomoEventBranch = (branch: string) => [
+	'trackEvent',
+	'User',
+	'Branche',
+	branch,
+]
+
 // Iframe
 export const getMatomoEventVisitViaIframe = (url: string) => [
 	'trackEvent',

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -30,8 +30,10 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router'
 import { Route, Routes, useSearchParams } from 'react-router-dom'
 import { Store } from 'redux'
+import { getMatomoEventBranch } from '../../analytics/matomo-events'
 import GroupModeSessionVignette from './conference/GroupModeSessionVignette'
 import EnquêteBanner from './enquête/BannerWrapper'
+
 import Landing from './Landing'
 import Navigation from './Navigation'
 import About from './pages/About'
@@ -253,7 +255,10 @@ const Main = () => {
 	const [simulationFromUrlHasBeenSet, setSimulationFromUrlHasBeenSet] =
 		useState(false)
 
-	const { trackPageView } = useMatomo()
+	const { trackPageView, trackEvent } = useMatomo()
+
+	trackEvent(getMatomoEventBranch(process.env.BRANCH))
+
 	const largeScreen = useMediaQuery('(min-width: 800px)')
 
 	// Or we retrive the simulation from the URL

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -28,6 +28,7 @@ module.exports = {
 		...HTMLPlugins({ injectTrackingScript: true }),
 		new webpack.DefinePlugin({
 			'process.env.NODE_ENV': JSON.stringify('development'),
+			'process.env.BRANCH': JSON.stringify(process.env.BRANCH),
 			'process.env.SERVER_URL': JSON.stringify(process.env.SERVER_URL),
 			'process.env.CONTEXT': JSON.stringify(process.env.CONTEXT),
 			'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN),

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -40,6 +40,7 @@ module.exports = {
 		}),
 		new webpack.DefinePlugin({
 			'process.env.NODE_ENV': JSON.stringify('production'),
+			'process.env.BRANCH': JSON.stringify(process.env.BRANCH),
 			'process.env.SERVER_URL': JSON.stringify(process.env.SERVER_URL),
 			'process.env.CONTEXT': JSON.stringify(process.env.CONTEXT),
 			'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN),


### PR DESCRIPTION
La [fonctionnalité de split testing](https://docs.netlify.com/site-deploys/split-testing/) de Netlify [bug sur iframe](https://answers.netlify.com/t/running-split-tests-in-an-iframe-adjust-nf-ab-cookie-settings/28754). Le cookie déposé par Netlify pour identifier la version du site de l'utilisateur n'est pas compatible avec l'iframe. Ce qui fait que la version serveur et client ne match pas toujours (et le client essaie donc de charger des ressources d'une autre branche).

Pour corriger cela on identifie la version iframe (via le paramètre iframe dans l'url) puis on set manuellement le cookie `nf_ab` avec [sameSite=None et secure](https://medium.com/trabe/cookies-and-iframes-f7cca58b3b9e). Enfin on recharge la page afin d'avoir la bonne version qui s'affiche. Cela entraine une perte de performance puisque le dom initial est chargé 2 fois. La perte de performance minimale (la requête dupliquée fait 1.6kb et délai d'autant le chargement des autres scripts) couplée à son périmètre restreint (le rechargement n'arrive que sur iframe) me semble acceptable en rapport des bénéfices apportés par la solution d'AB Testing de Netlify.

À noter : sur la plupart des navigateurs, l'iframe ne fonctionnera plus (ou tout du moins érratiquement) en mode navigation privée (il faut que les cookies tiers soient acceptés)