### PR TITLE
Retire le lazy loading sur l'image de la page d'accueil

### DIFF
--- a/source/components/AnimatedIllustration.tsx
+++ b/source/components/AnimatedIllustration.tsx
@@ -2,14 +2,20 @@ import { useEffect, useRef, useState } from 'react'
 import IllustrationSVG from './IllustrationSVG'
 
 const windowAnimationDuration = '60s'
+
 export default ({ small }: { small?: boolean }) => {
 	const [cycling, pleaseCycle] = useState(false)
-	const svgRef = useRef(null)
+	const svgRef = useRef<HTMLOrSVGElement & { onclick: () => void }>()
+
 	useEffect(() => {
+		if (!svgRef.current) return
+
 		svgRef.current.onclick = () => pleaseCycle(true)
 	}, [svgRef])
+
 	return (
 		<div
+			aria-hidden="true"
 			css={`
 				svg {
 					max-width: ${small ? '15rem' : '32rem'};

--- a/source/sites/publicodes/Landing.tsx
+++ b/source/sites/publicodes/Landing.tsx
@@ -1,7 +1,8 @@
+import AnimatedIllustration from '@/components/AnimatedIllustration'
 import Title from '@/components/groupe/Title'
 import animate from '@/components/ui/animate'
 import LogoADEME from '@/images/logoADEME.svg'
-import React, { Suspense, useContext } from 'react'
+import { useContext } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import {
@@ -25,19 +26,6 @@ import { useMatomo } from '../../contexts/MatomoContext'
 import useMediaQuery from '../../hooks/useMediaQuery'
 import LandingExplanations from './LandingExplanations'
 import { useProfileData } from './Profil'
-
-const LazyIllustration = React.lazy(
-	() =>
-		import(
-			/* webpackChunkName: 'AnimatedIllustration' */ '@/components/AnimatedIllustration'
-		)
-)
-
-const Illustration = () => (
-	<Suspense fallback={null}>
-		<LazyIllustration />
-	</Suspense>
-)
 
 export default () => {
 	const { trackEvent } = useMatomo()
@@ -64,7 +52,7 @@ export default () => {
 							</Trans>
 						}
 					/>
-					{mobile && <Illustration aria-hidden="true" />}
+					{mobile && <AnimatedIllustration />}
 					<p>
 						<Trans i18nKey={'sites.publicodes.Landing.description'}>
 							En 10 minutes, obtenez une estimation de votre empreinte carbone
@@ -129,7 +117,7 @@ export default () => {
 						</div>
 					</div>
 				</HeaderContent>
-				{!mobile && <Illustration aria-hidden="true" />}
+				{!mobile && <AnimatedIllustration />}
 			</LandingHeaderWrapper>
 
 			<div


### PR DESCRIPTION
#1200 

Ici le poids de l'image en soi n'est pas le problème mais plutôt la manière dont elle était chargée, en lazy loading, et donc avec un délai, ce qui faisait se décaler le contenu de la page vers le bas, ce qui est pénalisé sur le plan du SEO.