### PR TITLE
fix(ui): remove package infos from the numbered mosaic descriptions

### DIFF
--- a/source/components/conversation/select/UI.js
+++ b/source/components/conversation/select/UI.js
@@ -59,6 +59,10 @@ export function MosaicItemLabel({
 	description,
 	isNotActive,
 }) {
+	// Removes information about the package from the description
+	description = description
+		? description.replace(/(^> ℹ️ .*\[.*\]\(.*\).$)+/, '')
+		: undefined
 	return (
 		<div
 			css={`
@@ -78,14 +82,16 @@ export function MosaicItemLabel({
 				</span>
 				{title}
 			</MosaicLabel>
-			<p
-				id={'description ' + title}
-				css={`
-					text-align: left !important;
-				`}
-			>
-				{description && description.split('\n')[0]}
-			</p>
+			{description !== undefined ? (
+				<p
+					id={'description ' + title}
+					css={`
+						text-align: left !important;
+					`}
+				>
+					{description.split('\n')[0]}
+				</p>
+			) : null}
 		</div>
 	)
 }


### PR DESCRIPTION
> Related to https://github.com/incubateur-ademe/nosgestesclimat/issues/1985

Don't show the rule's source package inside numbered mosaics.

Before:
![Screenshot from 2023-09-05 15-22-36](https://github.com/incubateur-ademe/nosgestesclimat-site/assets/44124798/bc9536ee-14ea-445d-b05a-7ef6e3d07b78)

After:
![Screenshot from 2023-09-05 15-22-58](https://github.com/incubateur-ademe/nosgestesclimat-site/assets/44124798/2cc46001-5565-4c0a-baee-440a47beb7d2)
