### PR TITLE
Nouvel Iframe de simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 dist/*
 !dist/_redirects
 !/dist/demo-iframe.html
+!/dist/demo-iframeSimulation.html
 .DS_Store
 yarn-error.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules/
 /cypress/screenshots/*
 # They are automatically generated when running cypress in CI
 /cypress/e2e/test-completion/persona-*.cy.js
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ node_modules/
 /cypress/screenshots/*
 # They are automatically generated when running cypress in CI
 /cypress/e2e/test-completion/persona-*.cy.js
-dist

--- a/dist/demo-iframe.html
+++ b/dist/demo-iframe.html
@@ -6,11 +6,12 @@
 	</head>
 
 	<body>
-
-			<h2>iframe paramétré</h2>
-			Ci-dessous, nosgestesclimat.fr intégré comme un iframe paramétré.
-			<script id="nosgestesclimat" src="/iframe.js" data-share-data="true"></script>
-
-
+		<h2>iframe paramétré</h2>
+		Ci-dessous, nosgestesclimat.fr intégré comme un iframe paramétré.
+		<script
+			id="nosgestesclimat"
+			src="/iframe.js"
+			data-share-data="true"
+		></script>
 	</body>
 </html>

--- a/dist/demo-iframeSimulation.html
+++ b/dist/demo-iframeSimulation.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="fr">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="initial-scale=1" />
+	</head>
+	<body>
+		<h2>Exemple d'intégration du test avec région fixée par l'intégrateur.</h2>
+		Ci-dessous, nosgestesclimat.fr intégré comme un iframe paramétré ne
+		contenant que la partie simulation du test. Dans cet exemple, la Suisse a
+		été définie comme étant la région par défaut du test.
+		<script
+			id="nosgestesclimat"
+			src="/iframeSimulation.js"
+			data-only-simulation="true"
+			data-localisation="CH"
+			data-share-data="true"
+		></script>
+	</body>
+</html>

--- a/dist/demo-iframeSimulation.html
+++ b/dist/demo-iframeSimulation.html
@@ -14,6 +14,7 @@
 			src="/iframeSimulation.js"
 			data-only-simulation="true"
 			data-localisation="CH"
+			data-pr="1872"
 		></script>
 	</body>
 </html>

--- a/dist/demo-iframeSimulation.html
+++ b/dist/demo-iframeSimulation.html
@@ -14,7 +14,6 @@
 			src="/iframeSimulation.js"
 			data-only-simulation="true"
 			data-localisation="CH"
-			data-share-data="true"
 		></script>
 	</body>
 </html>

--- a/source/Provider.tsx
+++ b/source/Provider.tsx
@@ -9,6 +9,7 @@ import { BrowserRouter } from 'react-router-dom'
 import reducers, { AppState } from 'Reducers/rootReducer'
 import { applyMiddleware, compose, createStore, Middleware, Store } from 'redux'
 import thunk from 'redux-thunk'
+import { IframeResizer } from './components/IframeResizer'
 import { MatomoProvider } from './contexts/MatomoContext'
 import RulesProvider from './RulesProvider'
 import { getIsIframe } from './utils'
@@ -85,6 +86,7 @@ export default function Provider({
 						color={iframeCouleur && decodeURIComponent(iframeCouleur)}
 					>
 						<IframeOptionsProvider>
+							<IframeResizer />
 							<SitePathProvider value={sitePaths}>
 								<I18nextProvider i18n={i18next}>
 									<BrowserRouter>

--- a/source/components/Footer.tsx
+++ b/source/components/Footer.tsx
@@ -1,24 +1,31 @@
-import { useContext } from 'react'
+import { AppState } from '@/reducers/rootReducer'
+import { getIsIframe } from '@/utils'
 import { Trans } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { Link, useLocation } from 'react-router-dom'
 import { useMediaQuery } from 'usehooks-ts'
 import DocumentationButton from '../sites/publicodes/DocumentationButton'
 import LandingContent from '../sites/publicodes/LandingContent'
 import { isFluidLayout } from '../sites/publicodes/utils'
-import { IframeOptionsContext } from './utils/IframeOptionsProvider'
 
 export default ({}) => {
 	const location = useLocation(),
 		path = decodeURIComponent(location.pathname)
 
-	const { isIframe } = useContext(IframeOptionsContext),
-		displaySponsorLogos =
-			path === '/' &&
-			// would be a repetition with header logos
-			!isIframe
+	const isIframe = getIsIframe()
+	const iframeOnlySimulationOption = useSelector(
+		(state: AppState) => state?.iframeOptions?.iframeOnlySimulation
+	)
+
+	const displaySponsorLogos =
+		path === '/' &&
+		// would be a repetition with header logos
+		!isIframe
 
 	const mobileNoFooter = !isFluidLayout(path)
 	const mobileScreen = useMediaQuery('(max-width: 800px)')
+
+	if (iframeOnlySimulationOption) return null
 
 	if (mobileScreen && mobileNoFooter) return null
 

--- a/source/components/IframeResizer.tsx
+++ b/source/components/IframeResizer.tsx
@@ -14,7 +14,6 @@ export function IframeResizer() {
 
 		const minHeight = 800 // Also used in iframe.js
 		const observer = new ResizeObserver(([entry]) => {
-			console.log(entry.contentRect.height)
 			const value = Math.max(minHeight, entry.contentRect.height)
 			window.parent?.postMessage({ kind: 'resize-height', value }, '*')
 		})

--- a/source/components/IframeResizer.tsx
+++ b/source/components/IframeResizer.tsx
@@ -1,0 +1,26 @@
+import { getIsIframe } from '@/utils'
+import { useEffect } from 'react'
+
+export function IframeResizer() {
+	const isIframe = getIsIframe()
+	useEffect(() => {
+		// The code below communicate with the iframe.js script on a host site
+		// to automatically resize the iframe when its inner content height
+		// change.
+
+		if (!isIframe) {
+			return
+		}
+
+		const minHeight = 800 // Also used in iframe.js
+		const observer = new ResizeObserver(([entry]) => {
+			console.log(entry.contentRect.height)
+			const value = Math.max(minHeight, entry.contentRect.height)
+			window.parent?.postMessage({ kind: 'resize-height', value }, '*')
+		})
+		observer.observe(window.document.body)
+		return () => observer.disconnect()
+	}, [isIframe])
+
+	return null
+}

--- a/source/components/Logo.tsx
+++ b/source/components/Logo.tsx
@@ -13,13 +13,14 @@ export default ({ showText, size = 'large' }) => {
 				display: flex;
 				align-items: center;
 				justify-content: center;
+				${iframeOnlySimulationOption &&
+				`
+				pointer-events: none;
+				`}
 			`}
 		>
 			<Link
 				to="/"
-				onClick={(event) =>
-					iframeOnlySimulationOption && event.preventDefault()
-				}
 				data-cypress-id="home-logo-link"
 				css={`
 					display: flex;

--- a/source/components/Logo.tsx
+++ b/source/components/Logo.tsx
@@ -1,62 +1,74 @@
+import { AppState } from '@/reducers/rootReducer'
+import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 
-export default ({ showText, size = 'large' }) => (
-	<div
-		css={`
-			width: 100%;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		`}
-	>
-		<Link
-			to="/"
-			data-cypress-id="home-logo-link"
+export default ({ showText, size = 'large' }) => {
+	const iframeOnlySimulationOption = useSelector(
+		(state: AppState) => state?.iframeOptions?.iframeOnlySimulation
+	)
+	return (
+		<div
 			css={`
+				width: 100%;
 				display: flex;
 				align-items: center;
 				justify-content: center;
-				text-decoration: none;
-				margin: ${{
-					large: '1rem auto',
-					medium: '1rem 3rem 0rem 0rem',
-					small: '.1rem auto',
-				}[size]};
-				img {
-					width: ${{ large: '100px', medium: '55px', small: '30px' }[size]};
-					height: auto;
-				}
 			`}
 		>
-			<img
-				src={`/images/petit-logo${size === 'large' ? '@2x' : ''}.png`}
-				srcSet="/images/petit-logo@2x.png 2x,
+			<Link
+				to="/"
+				onClick={(event) =>
+					iframeOnlySimulationOption && event.preventDefault()
+				}
+				data-cypress-id="home-logo-link"
+				css={`
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					text-decoration: none;
+					margin: ${{
+						large: '1rem auto',
+						medium: '1rem 3rem 0rem 0rem',
+						small: '.1rem auto',
+					}[size]};
+					img {
+						width: ${{ large: '100px', medium: '55px', small: '30px' }[size]};
+						height: auto;
+					}
+				`}
+			>
+				<img
+					src={`/images/petit-logo${size === 'large' ? '@2x' : ''}.png`}
+					srcSet="/images/petit-logo@2x.png 2x,
 							/images/petit-logo@3x.png 3x"
-				width="75"
-				height="75"
-			/>
-			{showText && (
-				<div
-					css={`
-						font-weight: 900;
-						line-height: ${{
-							large: '1.5rem',
-							medium: '1.05rem',
-							small: '1rem',
-						}[size]};
-						color: var(--darkColor);
-						text-transform: uppercase;
-						font-size: ${{ large: '160%', medium: '113%', small: '60%' }[size]};
-						margin-left: 0.2rem;
-					`}
-				>
-					Nos
-					<br />
-					Gestes
-					<br />
-					Climat
-				</div>
-			)}
-		</Link>
-	</div>
-)
+					width="75"
+					height="75"
+				/>
+				{showText && (
+					<div
+						css={`
+							font-weight: 900;
+							line-height: ${{
+								large: '1.5rem',
+								medium: '1.05rem',
+								small: '1rem',
+							}[size]};
+							color: var(--darkColor);
+							text-transform: uppercase;
+							font-size: ${{ large: '160%', medium: '113%', small: '60%' }[
+								size
+							]};
+							margin-left: 0.2rem;
+						`}
+					>
+						Nos
+						<br />
+						Gestes
+						<br />
+						Climat
+					</div>
+				)}
+			</Link>
+		</div>
+	)
+}

--- a/source/components/localisation/Localisation.tsx
+++ b/source/components/localisation/Localisation.tsx
@@ -49,7 +49,8 @@ export default ({ title = 'Ma région de simulation' }) => {
 						<p>
 							{localisation?.userChosen ? (
 								<span>
-									<Trans>Vous avez choisi</Trans>{' '}
+									<Trans>Vous avez choisi </Trans>
+									{countryName}
 								</span>
 							) : iframeLocalisationOption ? (
 								<span>
@@ -59,8 +60,8 @@ export default ({ title = 'Ma région de simulation' }) => {
 								<span>
 									<Trans>
 										Nous avons détecté que vous faites cette simulation depuis{' '}
-										{countryName}
-									</Trans>{' '}
+									</Trans>
+									{countryName}
 								</span>
 							)}
 							<img

--- a/source/components/localisation/Localisation.tsx
+++ b/source/components/localisation/Localisation.tsx
@@ -24,6 +24,9 @@ export default ({ title = 'Ma région de simulation' }) => {
 	const [chosenIp, _] = usePersistingState('IP', undefined)
 	const localisation: Localisation | undefined = useLocalisation(chosenIp)
 	const dispatch = useDispatch()
+	const iframeLocalisationOption = useSelector(
+		(state: AppState) => state?.iframeOptions?.iframeLocalisation
+	)
 	const regionParams: Region | undefined = useSupportedRegion(
 		localisation?.country?.code
 	)
@@ -32,6 +35,10 @@ export default ({ title = 'Ma région de simulation' }) => {
 		DEFAULT_REGION_MODEL_AUTHOR,
 	]
 	const countryName = useCountryNameInCurrentLang(localisation)
+
+	const versionName = regionParams
+		? regionParams[currentLang]['gentilé'] ?? regionParams[currentLang]['nom']
+		: localisation?.country?.name
 
 	return (
 		<div>
@@ -44,17 +51,22 @@ export default ({ title = 'Ma région de simulation' }) => {
 								<span>
 									<Trans>Vous avez choisi</Trans>{' '}
 								</span>
+							) : iframeLocalisationOption ? (
+								<span>
+									<Trans> Vous utilisez la version {versionName} du test</Trans>
+								</span>
 							) : (
 								<span>
 									<Trans>
-										Nous avons détecté que vous faites cette simulation depuis
+										Nous avons détecté que vous faites cette simulation depuis{' '}
+										{countryName}
 									</Trans>{' '}
 								</span>
 							)}
-							{countryName}
 							<img
 								src={flag}
 								aria-hidden="true"
+								alt="Country Flag"
 								css={`
 									height: 1rem;
 									margin: 0 0.3rem;

--- a/source/components/localisation/Localisation.tsx
+++ b/source/components/localisation/Localisation.tsx
@@ -43,83 +43,81 @@ export default ({ title = 'Ma région de simulation' }) => {
 	return (
 		<div>
 			<h2>📍 {t(title)}</h2>
-			{localisation != null ? (
-				regionParams ? (
-					<>
-						<p>
-							{localisation?.userChosen ? (
-								<span>
-									<Trans>Vous avez choisi </Trans>
-									{countryName}
-								</span>
-							) : iframeLocalisationOption ? (
-								<span>
-									<Trans> Vous utilisez la version {versionName} du test</Trans>
-								</span>
-							) : (
-								<span>
-									<Trans>
-										Nous avons détecté que vous faites cette simulation depuis{' '}
-									</Trans>
-									{countryName}
-								</span>
-							)}
-							<img
-								src={flag}
-								aria-hidden="true"
-								alt="Country Flag"
-								css={`
-									height: 1rem;
-									margin: 0 0.3rem;
-									vertical-align: sub;
-								`}
-							/>
-							.{' '}
-							{localisation?.userChosen && (
-								<button
-									className="ui__ dashed-button"
-									onClick={() => {
-										dispatch(resetLocalisation())
-									}}
-								>
-									<Trans>Revenir chez moi 🔙</Trans>
-								</button>
-							)}
-						</p>
-						<RegionModelAuthors authors={authors} />
-					</>
-				) : (
-					localisation?.country && (
-						<p>
-							<Trans>
-								Nous avons détecté que vous faites cette simulation depuis
-							</Trans>{' '}
-							{countryName}
-							<img
-								src={flag}
-								aria-hidden="true"
-								css={`
-									height: 1rem;
-									margin: 0 0.3rem;
-									vertical-align: sub;
-								`}
-							/>
-							.
-							<Trans i18nKey="components.localisation.Localisation.warnMessage">
-								Pour le moment, il n'existe pas de modèle de calcul pour{' '}
-								{{ countryName }}, le modèle Français vous est proposé par
-								défaut.
-							</Trans>
-						</p>
-					)
-				)
-			) : (
+			{!regionParams && localisation?.fetchDone ? (
 				<p>
 					<Trans i18nKey="components.localisation.Localisation.warnMessage2">
 						Nous n'avons pas pu détecter votre pays de simulation, le modèle
 						Français vous est proposé par défaut.
 					</Trans>{' '}
 				</p>
+			) : regionParams ? (
+				<>
+					<p>
+						{localisation?.userChosen ? (
+							<span>
+								<Trans>Vous avez choisi </Trans>
+								{countryName}
+							</span>
+						) : iframeLocalisationOption ? (
+							<span>
+								<Trans> Vous utilisez la version {versionName} du test</Trans>
+							</span>
+						) : (
+							<span>
+								<Trans>
+									Nous avons détecté que vous faites cette simulation depuis{' '}
+								</Trans>
+								{countryName}
+							</span>
+						)}
+						<img
+							src={flag}
+							aria-hidden="true"
+							alt="Country Flag"
+							css={`
+								height: 1rem;
+								margin: 0 0.3rem;
+								vertical-align: sub;
+							`}
+						/>
+						.{' '}
+						{localisation?.userChosen && (
+							<button
+								className="ui__ dashed-button"
+								onClick={() => {
+									dispatch(resetLocalisation())
+								}}
+							>
+								<Trans>Revenir chez moi 🔙</Trans>
+							</button>
+						)}
+					</p>
+					<RegionModelAuthors authors={authors} />
+				</>
+			) : (
+				localisation?.country && (
+					<p>
+						<Trans>
+							Nous avons détecté que vous faites cette simulation depuis
+						</Trans>{' '}
+						{countryName}
+						<img
+							src={flag}
+							aria-hidden="true"
+							alt="Country Flag"
+							css={`
+								height: 1rem;
+								margin: 0 0.3rem;
+								vertical-align: sub;
+							`}
+						/>
+						.
+						<Trans i18nKey="components.localisation.Localisation.warnMessage">
+							Pour le moment, il n'existe pas de modèle de calcul pour{' '}
+							{{ countryName }}, le modèle Français vous est proposé par défaut.
+						</Trans>
+					</p>
+				)
 			)}
 			{}
 			<RegionSelector />

--- a/source/components/localisation/LocalisationMessage.tsx
+++ b/source/components/localisation/LocalisationMessage.tsx
@@ -32,6 +32,12 @@ export default (): JSX.Element => {
 		? regionParams[currentLang]['gentilé'] ?? regionParams[currentLang]['nom']
 		: localisation?.country?.name
 
+	const iframeLocalisationOption = useSelector(
+		(state: AppState) => state?.iframeOptions?.iframeLocalisation
+	)
+
+	if (iframeLocalisationOption) return
+
 	if (messagesRead.includes(code)) return
 
 	if (code === defaultModelRegionCode) return

--- a/source/components/localisation/LocalisationMessage.tsx
+++ b/source/components/localisation/LocalisationMessage.tsx
@@ -42,6 +42,10 @@ export default (): JSX.Element => {
 
 	if (code === defaultModelRegionCode) return
 
+	if (localisation == null) return
+
+	if (!code && !localisation.fetchDone) return
+
 	return (
 		<IllustratedMessage
 			emoji="📍"
@@ -68,7 +72,7 @@ export default (): JSX.Element => {
 								</span>
 							)}{' '}
 						</p>
-					) : localisation ? (
+					) : code ? (
 						<p>
 							<Trans>
 								Nous avons détecté que vous faites cette simulation depuis

--- a/source/components/localisation/useLocalisation.ts
+++ b/source/components/localisation/useLocalisation.ts
@@ -63,6 +63,10 @@ export default () => {
 			return undefined
 		}
 
+		if (localisation?.fetchDone) {
+			return undefined
+		}
+
 		const asyncFecthAPI = async () => {
 			await fetch(API)
 				.then((res) => {
@@ -88,8 +92,8 @@ export default () => {
 					)
 				})
 		}
-
 		asyncFecthAPI()
+		dispatch(setLocalisation({ ...localisation, fetchDone: true }))
 		return undefined
 	}, [localisation, iframeLocalisationOption, dispatch])
 

--- a/source/components/localisation/useLocalisation.ts
+++ b/source/components/localisation/useLocalisation.ts
@@ -26,7 +26,7 @@ export default () => {
 	)
 
 	useEffect(() => {
-		if (localisation?.country != null) {
+		if (localisation?.country != null && localisation?.country?.code != null) {
 			return undefined
 		}
 
@@ -71,7 +71,7 @@ export default () => {
 		}
 
 		return undefined
-	}, [localisation])
+	}, [localisation, iframeLocalisationOption])
 
 	return localisation
 }

--- a/source/components/localisation/useLocalisation.ts
+++ b/source/components/localisation/useLocalisation.ts
@@ -21,12 +21,25 @@ export default () => {
 		(state: AppState) => state.currentLang
 	).toLowerCase()
 
-	const regionParams: Region | undefined = useSupportedRegion(
-		iframeLocalisationOption
-	)
+	const iframeRegionParams: Region | undefined =
+		iframeLocalisationOption && useSupportedRegion(iframeLocalisationOption)
 
+	console.log(iframeRegionParams)
 	useEffect(() => {
 		if (localisation?.country != null && localisation?.country?.code != null) {
+			return undefined
+		}
+
+		if (iframeLocalisationOption) {
+			dispatch(
+				setLocalisation({
+					country: {
+						code: iframeRegionParams?.[currentLang]?.code,
+						name: iframeRegionParams?.[currentLang]?.nom,
+					},
+					userChosen: false,
+				})
+			)
 			return undefined
 		}
 
@@ -56,20 +69,7 @@ export default () => {
 				})
 		}
 
-		if (iframeLocalisationOption) {
-			dispatch(
-				setLocalisation({
-					country: {
-						code: regionParams?.[currentLang]?.code,
-						name: regionParams?.[currentLang]?.nom,
-					},
-					userChosen: false,
-				})
-			)
-		} else {
-			asyncFecthAPI()
-		}
-
+		asyncFecthAPI()
 		return undefined
 	}, [localisation, iframeLocalisationOption])
 

--- a/source/components/localisation/useLocalisation.ts
+++ b/source/components/localisation/useLocalisation.ts
@@ -16,9 +16,6 @@ export default () => {
 	const iframeLocalisationOption: string | undefined = useSelector(
 		(state: AppState) => state?.iframeOptions?.iframeLocalisation
 	)
-
-	console.log(iframeLocalisationOption)
-
 	const currentLang = useSelector(
 		(state: AppState) => state.currentLang
 	).toLowerCase()
@@ -27,13 +24,16 @@ export default () => {
 		iframeLocalisationOption
 	)
 
-	console.log(iframeRegionParams)
 	useEffect(() => {
 		if (localisation?.country != null && localisation?.country?.code != null) {
 			return undefined
 		}
 
-		if (iframeLocalisationOption) {
+		if (!iframeRegionParams) {
+			return undefined
+		}
+
+		if (iframeLocalisationOption && iframeRegionParams) {
 			dispatch(
 				setLocalisation({
 					country: {
@@ -43,6 +43,23 @@ export default () => {
 					userChosen: false,
 				})
 			)
+		}
+
+		return undefined
+	}, [
+		localisation,
+		iframeLocalisationOption,
+		iframeRegionParams,
+		dispatch,
+		currentLang,
+	])
+
+	useEffect(() => {
+		if (iframeLocalisationOption) {
+			return undefined
+		}
+
+		if (localisation?.country != null && localisation?.country?.code != null) {
 			return undefined
 		}
 
@@ -74,7 +91,7 @@ export default () => {
 
 		asyncFecthAPI()
 		return undefined
-	}, [localisation, iframeLocalisationOption])
+	}, [localisation, iframeLocalisationOption, dispatch])
 
 	return localisation
 }

--- a/source/components/localisation/useLocalisation.ts
+++ b/source/components/localisation/useLocalisation.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { setLocalisation } from '../../actions/actions'
 import { AppState } from '../../reducers/rootReducer'
+import { Region, useSupportedRegion } from './utils'
 
 const API = '/.netlify/functions/geolocation'
 
@@ -12,6 +13,17 @@ const API = '/.netlify/functions/geolocation'
 export default () => {
 	const dispatch = useDispatch()
 	const localisation = useSelector((state: AppState) => state.localisation)
+	const iframeLocalisationOption = useSelector(
+		(state: AppState) => state?.iframeOptions?.iframeLocalisation
+	)
+
+	const currentLang = useSelector(
+		(state: AppState) => state.currentLang
+	).toLowerCase()
+
+	const regionParams: Region | undefined = useSupportedRegion(
+		iframeLocalisationOption
+	)
 
 	useEffect(() => {
 		if (localisation?.country != null) {
@@ -44,7 +56,20 @@ export default () => {
 				})
 		}
 
-		asyncFecthAPI()
+		if (iframeLocalisationOption) {
+			dispatch(
+				setLocalisation({
+					country: {
+						code: regionParams?.[currentLang]?.code,
+						name: regionParams?.[currentLang]?.nom,
+					},
+					userChosen: false,
+				})
+			)
+		} else {
+			asyncFecthAPI()
+		}
+
 		return undefined
 	}, [localisation])
 

--- a/source/components/localisation/useLocalisation.ts
+++ b/source/components/localisation/useLocalisation.ts
@@ -13,16 +13,19 @@ const API = '/.netlify/functions/geolocation'
 export default () => {
 	const dispatch = useDispatch()
 	const localisation = useSelector((state: AppState) => state.localisation)
-	const iframeLocalisationOption = useSelector(
+	const iframeLocalisationOption: string | undefined = useSelector(
 		(state: AppState) => state?.iframeOptions?.iframeLocalisation
 	)
+
+	console.log(iframeLocalisationOption)
 
 	const currentLang = useSelector(
 		(state: AppState) => state.currentLang
 	).toLowerCase()
 
-	const iframeRegionParams: Region | undefined =
-		iframeLocalisationOption && useSupportedRegion(iframeLocalisationOption)
+	const iframeRegionParams: Region | undefined = useSupportedRegion(
+		iframeLocalisationOption
+	)
 
 	console.log(iframeRegionParams)
 	useEffect(() => {

--- a/source/components/localisation/utils.ts
+++ b/source/components/localisation/utils.ts
@@ -51,7 +51,7 @@ export function useSupportedRegion(
 	const supportedRegions: SupportedRegions = useSelector(
 		(state: AppState) => state.supportedRegions
 	)
-
+	console.log(supportedRegions)
 	// Check for undefined AFTER useSelector, because hooks can't be called conditionally
 	if (inputCode === undefined) {
 		return undefined

--- a/source/components/localisation/utils.ts
+++ b/source/components/localisation/utils.ts
@@ -35,8 +35,9 @@ export type SupportedRegions = {
 }
 
 export type Localisation = {
-	country: { code: RegionCode; name: string }
-	userChosen: boolean
+	country?: { code: RegionCode; name: string }
+	userChosen?: boolean
+	fetchDone?: boolean
 }
 
 export const defaultModelRegionCode = 'FR'

--- a/source/components/localisation/utils.ts
+++ b/source/components/localisation/utils.ts
@@ -51,7 +51,6 @@ export function useSupportedRegion(
 	const supportedRegions: SupportedRegions = useSelector(
 		(state: AppState) => state.supportedRegions
 	)
-	console.log(supportedRegions)
 	// Check for undefined AFTER useSelector, because hooks can't be called conditionally
 	if (inputCode === undefined) {
 		return undefined

--- a/source/locales/ui/ui-en-us.yaml
+++ b/source/locales/ui/ui-en-us.yaml
@@ -920,3 +920,9 @@ entries:
   Créer un groupe: Create a group
   'Oups ! Désolé, une erreur est survenue.': Oops! Sorry, an error has occurred.
   Nos équipes ont été prévenues ; veuillez réessayer d'accéder à cette page plus tard.: Our teams have been notified; please try to access this page again later.
+  Choisissez une option: Choose an option
+  Groupes: Groups
+  'Vous avez choisi ': 'You have chosen '
+  Fermer le bandeau de feedback: Close feedback banner
+  ' Vous utilisez la version {versionName} du test': ' You are using the {versionName} version of the test'
+  'Nous avons détecté que vous faites cette simulation depuis ': 'We have detected that you have been running this simulation since '

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -720,3 +720,6 @@ entries:
   Choisissez une option: Choisissez une option
   Fermer le bandeau de feedback: Fermer le bandeau de feedback
   Groupes: Groupes
+  ' Vous utilisez la version {versionName} du test': ' Vous utilisez la version {versionName} du test'
+  'Nous avons détecté que vous faites cette simulation depuis ': 'Nous avons détecté que vous faites cette simulation depuis '
+  'Vous avez choisi ': 'Vous avez choisi '

--- a/source/reducers/rootReducer.ts
+++ b/source/reducers/rootReducer.ts
@@ -348,10 +348,10 @@ type LocalisationAction = { type: string } & Localisation
 
 function localisation(
 	state = null,
-	{ type, country, userChosen }: LocalisationAction
+	{ type, country, userChosen, fetchDone = false }: LocalisationAction
 ): Localisation | null {
 	if (type === 'SET_LOCALISATION') {
-		return { country, userChosen }
+		return { country, userChosen, fetchDone }
 	} else if (type === 'RESET_LOCALISATION') {
 		return null
 	} else {

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -183,6 +183,10 @@ export default function Root() {
 		document?.location.search.substring(1)
 	).get('localisation')
 
+	const iframeOnlySimulation = new URLSearchParams(
+		document?.location.search.substring(1)
+	).get('onlySimulation')
+
 	// We retrieve the User object from local storage to initialize the store.
 	const persistedUser = fetchUser()
 
@@ -228,10 +232,10 @@ export default function Root() {
 				tutorials: persistedUser.tutorials,
 				localisation: persistedUser.localisation,
 				currentLang,
-				iframeOptions: { iframeShareData },
 				iframeOptions: {
 					iframeShareData,
 					iframeLocalisation,
+					iframeOnlySimulation,
 				},
 				actionChoices: persistedSimulation?.actionChoices ?? {},
 				storedTrajets: persistedSimulation?.storedTrajets ?? {},

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -322,7 +322,6 @@ const Main = () => {
 					css={`
 						@media (min-width: 800px) {
 							display: flex;
-							min-height: 100vh;
 							padding-top: 1rem;
 						}
 

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -179,6 +179,10 @@ export default function Root() {
 		document?.location.search.substring(1)
 	).get('shareData')
 
+	const iframeLocalisation = new URLSearchParams(
+		document?.location.search.substring(1)
+	).get('localisation')
+
 	// We retrieve the User object from local storage to initialize the store.
 	const persistedUser = fetchUser()
 
@@ -225,6 +229,10 @@ export default function Root() {
 				localisation: persistedUser.localisation,
 				currentLang,
 				iframeOptions: { iframeShareData },
+				iframeOptions: {
+					iframeShareData,
+					iframeLocalisation,
+				},
 				actionChoices: persistedSimulation?.actionChoices ?? {},
 				storedTrajets: persistedSimulation?.storedTrajets ?? {},
 				storedAmortissementAvion:

--- a/source/sites/publicodes/iframe.js
+++ b/source/sites/publicodes/iframe.js
@@ -1,10 +1,11 @@
 const script =
-		document.getElementById('ecolab-climat') ||
-		document.getElementById('nosgestesclimat'),
-	integratorUrl = encodeURIComponent(window.location.href.toString())
+	document.getElementById('ecolab-climat') ||
+	document.getElementById('nosgestesclimat')
+
+const integratorUrl = encodeURIComponent(window.location.href.toString())
 
 const srcURL = new URL(script.src)
-const hostname = srcURL.hostname || 'nosgestesclimat.fr'
+const hostname = srcURL.origin || 'https://nosgestesclimat.fr'
 
 const possibleOptions = [
 	{ key: 'shareData', legacy: 'partagedatafinsimulation' },
@@ -17,7 +18,7 @@ const optionFragments = possibleOptions.map(({ key, legacy }) => {
 	return value != null ? `&${key}=${value}` : ''
 })
 
-const src = `https://${hostname}/?iframe&integratorUrl=${integratorUrl}${optionFragments.join(
+const src = `${hostname}/?iframe&integratorUrl=${integratorUrl}${optionFragments.join(
 	''
 )}`
 

--- a/source/sites/publicodes/iframeSimulation.js
+++ b/source/sites/publicodes/iframeSimulation.js
@@ -43,7 +43,6 @@ for (var key in iframeAttributes) {
 script.parentNode.insertBefore(iframe, script)
 
 window.addEventListener('message', function (evt) {
-	console.log(evt)
 	if (evt.data.kind === 'resize-height') {
 		iframe.style.height = `${evt.data.value}px`
 	}

--- a/source/sites/publicodes/iframeSimulation.js
+++ b/source/sites/publicodes/iframeSimulation.js
@@ -10,6 +10,7 @@ const hostname = srcURL.origin || 'https://nosgestesclimat.fr'
 const possibleOptions = [
 	{ key: 'shareData', legacy: 'partagedatafinsimulation' },
 	{ key: 'lang' },
+	{ key: 'localisation' },
 ]
 
 const optionFragments = possibleOptions.map(({ key, legacy }) => {

--- a/source/sites/publicodes/iframeSimulation.js
+++ b/source/sites/publicodes/iframeSimulation.js
@@ -12,12 +12,13 @@ const possibleOptions = [
 	{ key: 'lang' },
 	{ key: 'localisation' },
 	{ key: 'onlySimulation' },
+	{ key: 'pr' },
 ]
 
 const optionFragments = possibleOptions.map(({ key, legacy }) => {
 	const value = script.dataset[key] || script.dataset[legacy]
 
-	return value != null ? `&${key}=${value}` : ''
+	return value != null ? `&${key === 'pr' ? 'PR' : key}=${value}` : ''
 })
 
 const src = `${hostname}/simulateur/bilan/?iframe&integratorUrl=${integratorUrl}${optionFragments.join(

--- a/source/sites/publicodes/iframeSimulation.js
+++ b/source/sites/publicodes/iframeSimulation.js
@@ -11,6 +11,7 @@ const possibleOptions = [
 	{ key: 'shareData', legacy: 'partagedatafinsimulation' },
 	{ key: 'lang' },
 	{ key: 'localisation' },
+	{ key: 'onlySimulation' },
 ]
 
 const optionFragments = possibleOptions.map(({ key, legacy }) => {

--- a/source/sites/publicodes/iframeSimulation.js
+++ b/source/sites/publicodes/iframeSimulation.js
@@ -1,0 +1,48 @@
+const script =
+	document.getElementById('ecolab-climat') ||
+	document.getElementById('nosgestesclimat')
+
+const integratorUrl = encodeURIComponent(window.location.href.toString())
+
+const srcURL = new URL(script.src)
+const hostname = srcURL.origin || 'https://nosgestesclimat.fr'
+
+const possibleOptions = [
+	{ key: 'shareData', legacy: 'partagedatafinsimulation' },
+	{ key: 'lang' },
+]
+
+const optionFragments = possibleOptions.map(({ key, legacy }) => {
+	const value = script.dataset[key] || script.dataset[legacy]
+
+	return value != null ? `&${key}=${value}` : ''
+})
+
+const src = `${hostname}/simulateur/bilan/?iframe&integratorUrl=${integratorUrl}${optionFragments.join(
+	''
+)}`
+
+const iframe = document.createElement('iframe')
+
+const iframeAttributes = {
+	src,
+	allowfullscreen: true,
+	webkitallowfullscreen: true,
+	mozallowfullscreen: true,
+	allow: 'fullscreen',
+	id: 'iframeNGC',
+	style: 'border: none; width: 100%; display: block; height: 800px',
+}
+
+for (var key in iframeAttributes) {
+	iframe.setAttribute(key, iframeAttributes[key])
+}
+
+script.parentNode.insertBefore(iframe, script)
+
+window.addEventListener('message', function (evt) {
+	console.log(evt)
+	if (evt.data.kind === 'resize-height') {
+		iframe.style.height = `${evt.data.value}px`
+	}
+})

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -35,6 +35,7 @@ module.exports.default = {
 	entry: {
 		publicodes: './source/sites/publicodes/entry.js',
 		iframe: './source/sites/publicodes/iframe.js',
+		iframeSimulation: './source/sites/publicodes/iframeSimulation.js',
 	},
 	output: {
 		path: path.resolve('./dist/'),


### PR DESCRIPTION
Suite au travail mené dans https://github.com/incubateur-ademe/nosgestesclimat/pull/1872, l'idée ici est de proposer une solution d'intégration du site dans un site intégrateur qui porte la responsabilité d'un modèle régionalisé dans un site "vitrine". 

On peut prendre ici l'exemple de https://nosgestesclimat.ch pour la suisse donc.

En bref, via le script de l'iframe, on a 2 nouvelles options.

L'option "data-localisation" qui permet de fixer la localisation pour charger le modèle voulu. Le bandeau de localisation et la détection auto sont alors désactivés.

L'option "data-only-simulation" qui permet de faire disparaitre le Footer NGC pour mettre en valeur celui du site intégrateur et la disparition de la redirection vers la home NGC via le logo. Un autre élément important, on affiche non plus la Landing NGC mais directement le test (et donc le tuto). A voir si c'est optimal, on pourra itérer rapidement :).

Pour le script en question :
```html
<script
	id="nosgestesclimat"
	src="/iframeSimulation.js"
	data-only-simulation="true"
	data-localisation="CH"
        data-PR="1872"
></script>
```
Démo : https://deploy-preview-1302--nosgestesclimat.netlify.app/demo-iframesimulation

- [x] Vérifier que tout fonctionne si localisation non fonctionnelle
- [x] Traduction